### PR TITLE
Fixes Azure Compute Resource Edit Page 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,42 @@
-
 language: ruby
-
-sudo: false
-dist: trusty
-
-script:
-  # not yet set up: - bundle exec rake rubocop
-  - bundle exec rake test
-
+cache:
+  - npm
+  - bundler
 rvm:
   - 2.3
-  - 2.4
-  - 2.5
-
-gemfile:
-  - Gemfile
-
-matrix:
-  fast_finish: true
-
-notifications:
-  email: false
+install:
+  - unset BUNDLE_GEMFILE
+  - cd ..
+  - git clone https://github.com/theforeman/foreman.git -b ${FOREMAN_CORE_BRANCH} --depth 1
+  - cd ${FOREMAN_PLUGIN_NAME}
+  - bundle install --jobs=3 --retry=3
+  - npm install eslint
+  - cd ../foreman
+  - echo "gemspec :path => '../${FOREMAN_PLUGIN_NAME}'" > bundler.d/${FOREMAN_PLUGIN_NAME}.local.rb
+  - ln -s settings.yaml.test config/settings.yaml
+  - ln -s database.yml.example config/database.yml
+  - bundle install --jobs=3 --retry=3 --without journald development postgresql mysql2 console journald
+  - npm install
+  - bundle exec rake webpack:compile
+  - bundle exec rake db:migrate RAILS_ENV=test
+script:
+  - cd ../${FOREMAN_PLUGIN_NAME}
+  - # bundle exec rubocop
+  - # node ./node_modules/.bin/eslint . app/**/*.js
+  - cd ../foreman
+  - bundle exec rake test:${FOREMAN_PLUGIN_NAME}
+  - bundle exec rake "plugin:assets:precompile[${FOREMAN_PLUGIN_NAME}]" RAILS_ENV=production
+env:
+  global:
+    - TESTOPTS=-v
+    - FOREMAN_PLUGIN_NAME=foreman_azure_rm
+  matrix:
+    - FOREMAN_CORE_BRANCH=develop
+addons:
+  apt:
+    packages:
+    - nodejs
+    - git
+    - libsqlite3-dev
+    - zlib1g-dev
+    - libvirt-dev

--- a/app/controllers/foreman_azure_rm/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_azure_rm/concerns/hosts_controller_extensions.rb
@@ -5,7 +5,7 @@ module ForemanAzureRM
       def sizes
         if (azure_rm_resource = Image.unscoped.find_by_uuid(params[:image_id])).present?
           resource = azure_rm_resource.compute_resource
-          render :json => resource.vm_sizes(params[:location_string]).map { |size| size.name }
+          render :json => resource.vm_sizes(params[:region_string]).map { |size| size.name }
         else
           no_sizes = _('The location you selected has no sizes associated with it')
           render :json => "[\"#{no_sizes}\"]"
@@ -16,11 +16,11 @@ module ForemanAzureRM
         azure_rm_image = Image.unscoped.find_by_uuid(params[:image_id])
         if azure_rm_image.present?
           azure_rm_resource = azure_rm_image.compute_resource
-          subnets           = azure_rm_resource.subnets(params[:location])
+          subnets           = azure_rm_resource.subnets(params[:region])
           if subnets.present?
-            render :json => azure_rm_resource.subnets(params[:location])
+            render :json => subnets
           else
-            no_subnets = _('The selected location has no subnets')
+            no_subnets = _('The selected region has no subnets')
             render :json => "[\"#{no_subnets}\"]"
           end
         else

--- a/app/models/concerns/fog_extensions/azurerm/compute.rb
+++ b/app/models/concerns/fog_extensions/azurerm/compute.rb
@@ -31,8 +31,8 @@ module FogExtensions
         @network_client.add_user_agent_information(telemetry)
       end
 
-      def list_available_sizes(location)
-        @compute_mgmt_client.virtual_machine_sizes.list(location).value()
+      def list_available_sizes(region)
+        @compute_mgmt_client.virtual_machine_sizes.list(region).value()
       end
 
       def list_all_vms

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -5,13 +5,13 @@
 %>
 
 <script>
-    function azure_rm_location_callback() {
-        azure_rm_get_size_from_location();
-        azure_rm_subnets_from_location();
+    function azure_rm_region_callback() {
+        azure_rm_get_size_from_region();
+        azure_rm_subnets_from_region();
     }
 
-    function azure_rm_get_size_from_location() {
-        var location = $('#azure_rm_location').val();
+    function azure_rm_get_size_from_region() {
+        var region = $('#azure_rm_region').val();
         var size_spinner = $('#azure_rm_size_spinner');
         var sizes = $('#azure_rm_size');
         var imageId = $('#azure_rm_image_id').val();
@@ -22,7 +22,7 @@
         }
         size_spinner.removeClass('hide');
         $.ajax({
-            data: {"location_string": location, "image_id": imageId},
+            data: {"region_string": region, "image_id": imageId},
             type: 'get',
             url: '/azure_rm/sizes',
             complete: function () {
@@ -47,19 +47,19 @@
         });
     }
 
-    function azure_rm_subnets_from_location() {
+    function azure_rm_subnets_from_region() {
         var imageId = $('#azure_rm_image_id').val();
         var subnets = $('#azure_rm_subnet');
-        var location = $('#azure_rm_location').val();
+        var region = $('#azure_rm_region').val();
         if (typeof tfm == 'undefined') {  // earlier than 1.13
             foreman.tools.showSpinner();
         } else {
             tfm.tools.showSpinner();
         }
         $.ajax({
-            data: {"image_id": imageId, "location": location},
-            type: "get",
-            url: "/azure_rm/subnets",
+            data: {"image_id": imageId, "region": region},
+            type: 'get',
+            url: '/azure_rm/subnets',
             complete: function () {
                 reloadOnAjaxComplete('#azure_rm_subnet');
                 if (typeof tfm == 'undefined') {  // earlier than 1.13
@@ -84,16 +84,16 @@
     }
 </script>
 
-<%= selectable_f f, :location, compute_resource.locations,
+<%= selectable_f f, :location, compute_resource.regions,
                  { :include_blank => _('Please select an Azure region') },
                  {
                      :label       => _('Azure Region'),
                      :required    => true,
-                     :id          => 'azure_rm_location',
+                     :id          => 'azure_rm_region',
                      :label_size  => "col-md-2",
-                     :onchange    => 'azure_rm_location_callback();',
+                     :onchange    => 'azure_rm_region_callback();',
                      :help_inline => spinner_button_f(f, _('Reload Images, Sizes, vNets'),
-                                                      'azure_rm_location_callback();',
+                                                      'azure_rm_region_callback();',
                                                       {
                                                           :id            => 'load_subnets_btn',
                                                           :spinner_id    => 'load_subnets_indicator',

--- a/foreman_azure_rm.gemspec
+++ b/foreman_azure_rm.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '< 2.0'
 
   s.add_development_dependency "rubocop"
+  s.add_dependency 'mocha', '~> 1.2', '>= 1.2.1'
 end

--- a/lib/foreman_azure_rm.rake
+++ b/lib/foreman_azure_rm.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Tests
+namespace :test do
+  desc 'Test foreman_azure_rm'
+  Rake::TestTask.new(:foreman_azure_rm) do |t|
+    test_dir = File.join(File.dirname(__FILE__), '..', 'test')
+    t.libs << ['test', test_dir]
+    t.pattern = "#{test_dir}/**/*_test.rb"
+    t.verbose = true
+    t.warning = false
+  end
+end

--- a/lib/foreman_azure_rm/engine.rb
+++ b/lib/foreman_azure_rm/engine.rb
@@ -78,5 +78,9 @@ module ForemanAzureRM
       )
       Fog::Compute::AzureRM::ManagedDisks.send(:include, FogExtensions::AzureRM::ManagedDisks)
     end
+
+    rake_tasks do
+      load "foreman_azure_rm.rake"
+    end
   end
 end

--- a/test/factories/azure.rb
+++ b/test/factories/azure.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+    factory :azure_cr, :parent => :compute_resource, :class => ForemanAzureRM::AzureRM do
+      provider 'AzureRM'
+      user 'azurermuser'
+      password 'azurermpassword'
+      url 'http://azurerm.example.com'
+      uuid 'azurermuuid'
+    end
+end

--- a/test/functional/azure_rm_test.rb
+++ b/test/functional/azure_rm_test.rb
@@ -1,0 +1,27 @@
+require_relative '../test_plugin_helper'
+
+module ForemanAzureRM
+  class ComputeResourcesControllerTest < ActionController::TestCase
+    tests ::ComputeResourcesController
+
+    setup { Fog.mock! }
+    teardown { Fog.unmock! }
+
+    test "should create a compute resource and return edit page" do
+      test_client = Fog::Resources::AzureRM.new(
+        tenant_id:       '',
+        client_id:       '',
+        client_secret:   '',
+        subscription_id: '',
+        :environment     => 'AzureCloud')
+
+      ForemanAzureRM::AzureRM.any_instance.stubs(:rg_client).returns(test_client)
+      test_client.stubs(:list_resource_groups).returns([])
+      @compute_resource =  FactoryBot.create(:azure_cr)
+
+      get :edit, params: { :id => @compute_resource.to_param }, session: set_session_user
+      assert_response :success
+      assert_template 'edit'
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,0 +1,6 @@
+# This calls the main test_helper in Foreman core
+require 'test_helper'
+
+# Add plugin to FactoryBot's paths
+FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
+FactoryBot.reload


### PR DESCRIPTION
This fixes [issue#8](https://github.com/theforeman/foreman_azure_rm/issues/8). The location taxonomy in foreman core is different than what Azure considers it's locations. Hence, to simplify and avoid any confusions, here we can prefer calling them as Regions. This PR would also contain tests for the edit page of Azure Compute Resource.