### PR TITLE
Fixes Client Secret value clears on edit

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -5,6 +5,11 @@ module ForemanAzureRM
     alias_attribute :app_ident, :url
     alias_attribute :tenant, :uuid
 
+    validates :user, :presence => true
+    validates :password, :presence => true
+    validates :url, :presence => true
+    validates :uuid, :presence => true
+
     before_create :test_connection
 
     class VMContainer

--- a/app/views/compute_resources/form/_azurerm.html.erb
+++ b/app/views/compute_resources/form/_azurerm.html.erb
@@ -1,5 +1,5 @@
 <%= text_f f, :url, :label => _('Client ID'), :required => true %>
-<%= password_f f, :password, :label => _('Client Secret'), :required => true %>
+<%= password_f f, :password, :label => _('Client Secret'), :keep_value => true, :required => true %>
 <%= text_f f, :user, :label => _('Subscription ID'), :required => true %>
 <%= text_f f, :uuid, :label => _('Tenant ID'), :required => true %>
 


### PR DESCRIPTION
This fixes [issue#12](https://github.com/theforeman/foreman_azure_rm/issues/12).
But, is also dependent on [issue#8](https://github.com/theforeman/foreman_azure_rm/issues/8) as we must first be able to open the edit page and then this issue can be observed and hence, fixed.