### PR TITLE
overwrite FogExtensions::AzureRM::Server::persisted? 

### DIFF
--- a/app/models/concerns/fog_extensions/azurerm/server.rb
+++ b/app/models/concerns/fog_extensions/azurerm/server.rb
@@ -16,6 +16,10 @@ module FogExtensions
         vm_status == 'running'
       end
 
+      def persisted?
+        !!identity && !!id
+      end
+
       def state
         vm_status
       end


### PR DESCRIPTION
this pull request overwrites the way 'compute_object.persisted?' is calculated. 
As in this scenario '!!identity' is always true it is not sufficient. Adding '!!id' seems reasonable. 
This should resolve #4 for at least foreman >= 1.18