### PR TITLE
rename ComputeResource.locations to fix edit compute resource error

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -35,7 +35,7 @@ module ForemanAzureRM
       [:image]
     end
 
-    def locations
+    def az_locations
       [
           'Central US',
           'South Central US',

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -84,7 +84,7 @@
     }
 </script>
 
-<%= selectable_f f, :location, compute_resource.locations,
+<%= selectable_f f, :location, compute_resource.az_locations,
                  { :include_blank => _('Please select an Azure region') },
                  {
                      :label       => _('Azure Region'),


### PR DESCRIPTION
This pull request internally renames ComputeResource.locations to ComputeResource.az_locations to resolve Issue #8 