### PR TITLE
Use excon connection library

### DIFF
--- a/lib/foreman_azure_rm/engine.rb
+++ b/lib/foreman_azure_rm/engine.rb
@@ -18,6 +18,9 @@ module ForemanAzureRM
     config.to_prepare do
       require 'fog/azurerm'
 
+      # Use excon as default so that HTTP Proxy settings of foreman works
+      Faraday::default_adapter=:excon
+
       require 'fog/azurerm/models/compute/server'
       require File.expand_path(
           '../../../app/models/concerns/fog_extensions/azurerm/server',


### PR DESCRIPTION
The faraday default adpater (Net::HTTP) doesn't use the HTTP Proxy
settings of Foreman. Use excon instead of Net::HTTP solves this issue
and all azure connections are passed through the configured HTTP Proxy