### PR TITLE
Fixes #27621 - Click on Compute profile fails

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -144,10 +144,11 @@ module ForemanAzureRM
     end
 
     def new_interface(attr = {})
-      # WIP
-      # calls nic_cards method in adapter
-      # causes compute profiles issue
-      # NetworkModels::NetworkInterface.new
+      NetworkModels::NetworkInterface.new
+    end
+
+    def editable_network_interfaces?
+      true
     end
 
     def vm_sizes(region)

--- a/app/views/compute_resources_vms/form/azurerm/_network.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_network.html.erb
@@ -1,5 +1,7 @@
 <%= selectable_f f, :network, [],
-                 { :include_blank => _('Please first select an image and an Azure region')},
+                 { :include_blank => _('Please first select an image and an Azure region'),
+                   :selected => nil
+                 },
                  {
                    :label => _('Azure Subnet'),
                    :required => true,
@@ -9,15 +11,18 @@
 %>
 
 <%= selectable_f f, :bridge, ['None', 'Dynamic', 'Static'],
-                 {},
+                 { :selected => nil },
                  {
-                     :label => _("Public IP"),
-                     :label_size => "col-md-2"
+                   :label => _("Public IP"),
+                   :label_size => "col-md-2"
                  }
 %>
 
 <%= checkbox_f f, :name,
-               { :label => _("Static Private IP"), :label_size => "col-md-2" },
-               'true',
-               'false'
+               {
+                 :label => _("Static Private IP"),
+                 :label_size => "col-md-2"
+               },
+             'true',
+             'false'
 %>


### PR DESCRIPTION
This commit fixes the failure that occurs upon clicking any selected Compute Profile.