### PR TITLE
Associate Host

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -97,11 +97,6 @@ module ForemanAzureRM
       AzureRMCompute.new(sdk: sdk)
     end
 
-    def stop
-      power_off
-      deallocate
-    end
-
     def provided_attributes
       super.merge({ :ip => :provisioning_ip_address })
     end
@@ -152,6 +147,10 @@ module ForemanAzureRM
 
     def vm_sizes(region)
       sdk.list_vm_sizes(region)
+    end
+
+    def associated_host(vm)
+      associate_by("ip", [vm.public_ip_address, vm.private_ip_address])
     end
 
     def vm_instance_defaults

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -35,6 +35,14 @@ module ForemanAzureRM
       vm_status
     end
 
+    def start
+      sdk.start_vm(@azure_vm.resource_group, name)
+    end
+
+    def stop
+      sdk.stop_vm(@azure_vm.resource_group, name)
+    end
+
     def vm_status
       sdk.check_vm_status(@azure_vm.resource_group, name)
     end

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -186,6 +186,13 @@
                :label => _('Comma seperated file URIs')
            }
   %>
+
+  <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1'
+  %>
+
+  <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine upon creation"), :label => _('Start'), :label_size => "col-md-2" } if new_vm && controller_name != "compute_attributes" 
+  %>
+
 <% end %>
 
 <div id="image_selection">

--- a/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -137,5 +137,14 @@ module ForemanAzureRM
       end
       vm_status
     end
+
+    def start_vm(rg_name, vm_name)
+      compute_client.virtual_machines.start(rg_name, vm_name)
+    end
+
+    def stop_vm(rg_name, vm_name)
+      compute_client.virtual_machines.power_off(rg_name, vm_name)
+      compute_client.virtual_machines.deallocate(rg_name, vm_name)
+    end
   end
 end


### PR DESCRIPTION
This PR provides the support for associating the azure vm as a host in foreman. In addition to that, it also fixes [Issue #27305](https://projects.theforeman.org/issues/27305) and [27304](https://projects.theforeman.org/issues/27304) against the PowerOn and PowerOff errors.