### PR TITLE
Fixes #28172 - No validation for region in CR create

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -59,7 +59,7 @@ module ForemanAzureRM
       [:image]
     end
 
-    def regions
+    def self.regions
       [
           ['West Europe', 'westeurope'],
           ['Central US', 'centralus'],
@@ -72,6 +72,9 @@ module ForemanAzureRM
           ['West US 2', 'westus2']
       ]
     end
+
+    validates :region, inclusion: { in: regions.collect(&:second),
+    message: "%{value} must be lowercase." }
 
     def resource_groups
       sdk.rgs

--- a/app/views/compute_resources/form/_azurerm.html.erb
+++ b/app/views/compute_resources/form/_azurerm.html.erb
@@ -3,7 +3,7 @@
 <%= text_f f, :user, :label => _('Subscription ID'), :required => true %>
 <%= text_f f, :uuid, :label => _('Tenant ID'), :required => true %>
 
-<%= selectable_f(f, :url, f.object.regions, {}, {:label => _('Azure Region'), :required => true }) %>
+<%= selectable_f(f, :url, f.object.class.regions, {}, {:label => _('Azure Region'), :required => true }) %>
 
 <div class="col-md-offset-2">
     <%= test_connection_button_f(f, true) %>


### PR DESCRIPTION
As per our documentation and azure-sdk standards, we use lowercased region for any action in AzureRM provisioning. Hence, this PR fixes the validation for region while creating compute resource through CLI.