### PR TITLE
Fixes #28456 - Compute Profile VM attributes column blank

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -119,6 +119,10 @@ module ForemanAzureRM
       @azure_vm.name = setuuid
     end
 
+    def vm_description
+        _("%{vm_size} VM Size") % {:vm_size => vm_size}
+    end
+
     # Following properties are for AzureRM
     # These are not part of Foreman's interface
 


### PR DESCRIPTION
[vm_description](https://github.com/theforeman/foreman/blob/15fed2f6e10daf20010d3f292c71b8457a8edaf3/app/models/concerns/fog_extensions/libvirt/server.rb#L42) method is defined for every compute resource in the fog_extensions that handles the [vm attrs name](https://github.com/theforeman/foreman/blob/15fed2f6e10daf20010d3f292c71b8457a8edaf3/app/models/compute_attribute.rb#L48).