### PR TITLE
Renaming to support better snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Foreman AzureRM Plugin
+# Foreman AzureRm Plugin
 
 ## Description
 ```foreman_azure_rm``` adds [Microsoft Azure Resource Manager](http://azure.com/) as a compute resource for The Foreman
@@ -23,9 +23,9 @@
 ## Configuration
 Go to **Infrastructure > Compute Resources** and click on "New Compute Resource".
 
-Choose the **AzureRM provider**, and fill in all the fields. You need a Subscription ID, Tenant ID, Client ID and a Client Secret which you can generate from your [Microsoft Azure subscription](https://docs.bmc.com/docs/cloudlifecyclemanagement/46/setting-up-a-tenant-id-client-id-and-client-secret-for-azure-resource-manager-provisioning-669202145.html#SettingupaTenantID,ClientID,andClientSecretforAzureResourceManagerprovisioning-SetupTenantIDPrereqPrerequisites)
+Choose the **Azure Resource Manager provider**, and fill in all the fields. You need a Subscription ID, Tenant ID, Client ID and a Client Secret which you can generate from your [Microsoft Azure subscription](https://docs.bmc.com/docs/cloudlifecyclemanagement/46/setting-up-a-tenant-id-client-id-and-client-secret-for-azure-resource-manager-provisioning-669202145.html#SettingupaTenantID,ClientID,andClientSecretforAzureResourceManagerprovisioning-SetupTenantIDPrereqPrerequisites)
 
-That's it. You're now ready to create and manage Azure resources in your new AzureRM compute resource. You should see something like this in the Compute Resource page:
+That's it. You're now ready to create and manage Azure resources in your new Azure Resource Manager compute resource. You should see something like this in the Compute Resource page:
 
 
 ![](https://i.imgur.com/9J7tPJa.png)

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ end
 
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'ForemanAzureRM'
+  rdoc.title    = 'ForemanAzureRm'
   rdoc.options << '--line-numbers'
   rdoc.rdoc_files.include('README.rdoc')
   rdoc.rdoc_files.include('lib/**/*.rb')

--- a/app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb
+++ b/app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb
@@ -1,4 +1,4 @@
-module ForemanAzureRM
+module ForemanAzureRm
   module Concerns
     module ComputeResourcesControllerExtensions
       include Api::Version2
@@ -7,9 +7,9 @@ module ForemanAzureRM
       update_api(:create, :update) do
         param :compute_resource, Hash do
           # Not adding :tenant as already specified in core.
-          param :app_ident, String, :desc => N_("Client ID for AzureRM")
-          param :secret_key, String, :desc => N_("Client Secret for AzureRM")
-          param :sub_id, String, :desc => N_("Subscription ID for AzureRM")
+          param :app_ident, String, :desc => N_("Client ID for AzureRm")
+          param :secret_key, String, :desc => N_("Client Secret for AzureRm")
+          param :sub_id, String, :desc => N_("Subscription ID for AzureRm")
         end
       end
 

--- a/app/controllers/foreman_azure_rm/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_azure_rm/concerns/hosts_controller_extensions.rb
@@ -1,4 +1,4 @@
-module ForemanAzureRM
+module ForemanAzureRm
   module Concerns
     module HostsControllerExtensions
       extend ActiveSupport::Concern

--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -1,5 +1,5 @@
 # This concern has the methods to be called inside azure_rm.rb
-module ForemanAzureRM
+module ForemanAzureRm
   module VMExtensions
     module ManagedVM
       extend ActiveSupport::Concern

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -3,8 +3,8 @@
 
 require 'base64'
 
-module ForemanAzureRM
-  class AzureRM < ComputeResource
+module ForemanAzureRm
+  class AzureRm < ComputeResource
 
     include VMExtensions::ManagedVM
     alias_attribute :sub_id, :user
@@ -40,7 +40,7 @@ module ForemanAzureRM
     end
 
     def sdk
-      @sdk ||= ForemanAzureRM::AzureSDKAdapter.new(tenant, app_ident, secret_key, sub_id)
+      @sdk ||= ForemanAzureRm::AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id)
     end
     
     def to_label
@@ -88,7 +88,7 @@ module ForemanAzureRM
     end
 
     def new_vm(args = {})
-      return AzureRMCompute.new(sdk: sdk) if args.empty? || args[:image_id].nil?
+      return AzureRmCompute.new(sdk: sdk) if args.empty? || args[:image_id].nil?
       opts = vm_instance_defaults.merge(args.to_h).deep_symbolize_keys
       # convert rails nested_attributes into a plain hash
       nested_args = opts.delete(:interfaces_attributes)
@@ -113,7 +113,7 @@ module ForemanAzureRM
           ifaces << new_interface(iface_attrs)
         end
       end
-      AzureRMCompute.new(azure_vm: raw_vm ,sdk: sdk, resource_group: opts[:resource_group], nics: ifaces)
+      AzureRmCompute.new(azure_vm: raw_vm ,sdk: sdk, resource_group: opts[:resource_group], nics: ifaces)
     end
 
     def provided_attributes
@@ -180,7 +180,7 @@ module ForemanAzureRM
       container = VMContainer.new
       # Load all vms of the region
       sdk.list_vms(region).each do |vm|
-        container.virtualmachines << AzureRMCompute.new(azure_vm: vm, sdk:sdk, nics: vm_nics(vm))
+        container.virtualmachines << AzureRmCompute.new(azure_vm: vm, sdk:sdk, nics: vm_nics(vm))
       end
       container
     end
@@ -243,9 +243,9 @@ module ForemanAzureRM
       logger.debug "Virtual Machine #{args[:vm_name]} Created Successfully."
       create_vm_extension(region, args)
       # return the vm object using azure_vm
-      AzureRMCompute.new(azure_vm: vm, sdk: sdk, resource_group: args[:resource_group], nics: vm_nics(vm))
+      AzureRmCompute.new(azure_vm: vm, sdk: sdk, resource_group: args[:resource_group], nics: vm_nics(vm))
     rescue RuntimeError => e
-      Foreman::Logging.exception('Unhandled Azure RM error', e)
+      Foreman::Logging.exception('Unhandled AzureRm error', e)
       destroy_vm vm.id if vm
       raise e
     end

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -1,5 +1,5 @@
-module ForemanAzureRM
-  class AzureRMCompute
+module ForemanAzureRm
+  class AzureRmCompute
     attr_accessor :sdk
     attr_accessor :azure_vm
     attr_accessor :resource_group
@@ -123,7 +123,7 @@ module ForemanAzureRM
         _("%{vm_size} VM Size") % {:vm_size => vm_size}
     end
 
-    # Following properties are for AzureRM
+    # Following properties are for AzureRm
     # These are not part of Foreman's interface
 
     def vm_size

--- a/foreman_azure_rm.gemspec
+++ b/foreman_azure_rm.gemspec
@@ -3,7 +3,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name    = 'foreman_azure_rm'
-  s.version = ForemanAzureRM::VERSION
+  s.version = ForemanAzureRm::VERSION
   s.date    = Date.today.to_s
   s.authors = ['Aditi Puntambekar', 'Shimon Shtein', 'Tyler Gregory']
   s.email   = ['puntambekaraditi@gmail.com', 'shteinshim@gmail.com', 'tdgregory@protonmail.com']

--- a/lib/foreman_azure_rm.rb
+++ b/lib/foreman_azure_rm.rb
@@ -4,7 +4,7 @@ require 'azure_mgmt_network'
 require 'azure_mgmt_storage'
 require 'azure_mgmt_compute'
 
-module ForemanAzureRM
+module ForemanAzureRm
   Storage = Azure::Storage::Profiles::Latest::Mgmt
   Network = Azure::Network::Profiles::Latest::Mgmt
   Compute = Azure::Compute::Profiles::Latest::Mgmt

--- a/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -1,5 +1,5 @@
-module ForemanAzureRM
-  class AzureSDKAdapter
+module ForemanAzureRm
+  class AzureSdkAdapter
     def initialize(tenant, app_ident, secret_key, sub_id)
       @tenant           = tenant
       @app_ident        = app_ident

--- a/lib/foreman_azure_rm/engine.rb
+++ b/lib/foreman_azure_rm/engine.rb
@@ -1,4 +1,4 @@
-module ForemanAzureRM
+module ForemanAzureRm
   class Engine < ::Rails::Engine
     engine_name 'foreman_azure_rm'
 
@@ -9,14 +9,14 @@ module ForemanAzureRM
     initializer 'foreman_azure_rm.register_plugin', :before => :finisher_hook do
       Foreman::Plugin.register :foreman_azure_rm do
         requires_foreman '>= 1.17'
-        compute_resource ForemanAzureRM::AzureRM
+        compute_resource ForemanAzureRm::AzureRm
         parameter_filter ComputeResource, :azure_vm, :tenant, :app_ident, :secret_key, :sub_id, :region
       end
     end
 
     initializer "foreman_azure_rm.add_rabl_view_path" do
       Rabl.configure do |config|
-        config.view_paths << ForemanAzureRM::Engine.root.join('app', 'views')
+        config.view_paths << ForemanAzureRm::Engine.root.join('app', 'views')
       end
     end
 
@@ -35,9 +35,9 @@ module ForemanAzureRM
       # Use excon as default so that HTTP Proxy settings of foreman works
       Faraday::default_adapter=:excon
 
-      ::HostsController.send(:include, ForemanAzureRM::Concerns::HostsControllerExtensions)
+      ::HostsController.send(:include, ForemanAzureRm::Concerns::HostsControllerExtensions)
 
-      Api::V2::ComputeResourcesController.send(:include, ForemanAzureRM::Concerns::ComputeResourcesControllerExtensions)
+      Api::V2::ComputeResourcesController.send(:include, ForemanAzureRm::Concerns::ComputeResourcesControllerExtensions)
     end
 
     rake_tasks do

--- a/lib/foreman_azure_rm/version.rb
+++ b/lib/foreman_azure_rm/version.rb
@@ -1,3 +1,3 @@
-module ForemanAzureRM
+module ForemanAzureRm
   VERSION = '2.0.3'.freeze
 end

--- a/test/factories/azure.rb
+++ b/test/factories/azure.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :azure_rm, :parent => :compute_resource, :class => ForemanAzureRM::AzureRM do
+  factory :azure_rm, :parent => :compute_resource, :class => ForemanAzureRm::AzureRm do
     add_attribute(:user) { '11111111-1111-1111-1111-111111111111' }
     add_attribute(:password) { '22222222-2222-2222-2222-222222222222' }
     add_attribute(:app_ident) { '33333333-3333-3333-3333-333333333333' }

--- a/test/functional/azure_rm_test.rb
+++ b/test/functional/azure_rm_test.rb
@@ -1,12 +1,12 @@
 require_relative '../test_plugin_helper'
 
-module ForemanAzureRM
+module ForemanAzureRm
   class ComputeResourcesControllerTest < ActionController::TestCase
     tests ::ComputeResourcesController
 
     setup do
       @test_sdk = mock('test_sdk') #creates an empty object
-      ForemanAzureRM::AzureRM.any_instance.stubs(:sdk).returns(@test_sdk)
+      ForemanAzureRm::AzureRm.any_instance.stubs(:sdk).returns(@test_sdk)
       @test_resource_client = mock('resource_client')
       @test_sdk.stubs(:resource_client).returns(@test_resource_client)
     end


### PR DESCRIPTION
Till now the modules and classes have been supporting snake case but not to a larger extent. Due to the need of introducing apipie:cache options for the installer, this older casing style causes build failure. Hence, better solution would be to support snake casing properly.