### PR TITLE
Display correct messages

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -74,7 +74,7 @@ module ForemanAzureRm
     end
 
     validates :region, inclusion: { in: regions.collect(&:second),
-    message: "%{value} must be lowercase." }
+    message: "%{value} must be lowercase eg. 'eastus'. No special characters allowed." }
 
     def resource_groups
       sdk.rgs

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -61,6 +61,10 @@ module ForemanAzureRm
       true
     end
 
+    def to_s
+      name
+    end
+
     def vm_status
       sdk.check_vm_status(@azure_vm.resource_group, name)
     end

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -88,7 +88,7 @@
 <% # This view has been modified and refers to the properties wrapper class %>
 
 <%= selectable_f f, :resource_group, resource_groups,
-               { :include_blank => true },
+               { :include_blank => _('Please select a Resource Group') },
                {
                    :disabled => resource_groups.empty?,
                    :label    => _('Resource Group'),
@@ -106,7 +106,7 @@
 %>
 
 <%= selectable_f f, :vm_size, compute_resource.vm_sizes.map { |size| size.name },
-               {},
+               { :include_blank => _('Please select a VM Size') },
                {
                    :label    => _('VM Size'),
                    :required => true,


### PR DESCRIPTION
The interpreter does an @vm.to_s internally which results in the literal .to_s translation of the compute or server class(eg. ForemanAzureRm::AzureRmCompute) name in Foreman. Hence, overriding `to_s` is required here to print the correct message while running and stopping the machine.

Also, adding a minor change of better validation message for incorrect region.