### PR TITLE
Fixes #28625 - Compute attributes set from CLI not shown on UI

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -88,7 +88,7 @@ module ForemanAzureRm
     end
 
     def new_vm(args = {})
-      return AzureRmCompute.new(sdk: sdk) if args.empty? || args[:image_id].nil?
+      return AzureRmCompute.new(sdk: sdk) if args.empty?
       opts = vm_instance_defaults.merge(args.to_h).deep_symbolize_keys
       # convert rails nested_attributes into a plain hash
       nested_args = opts.delete(:interfaces_attributes)
@@ -104,7 +104,6 @@ module ForemanAzureRm
                              platform:        opts[:platform],
                              ssh_key_data:    opts[:ssh_key_data],
                              os_disk_caching: opts[:os_disk_caching],
-                             vhd_path:        opts[:image_id],
                              premium_os_disk: opts[:premium_os_disk]
                             )
       if opts[:interfaces].present?

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -185,6 +185,6 @@
                    :required   => true,
                    :label_size => "col-md-2",
                    :id         => 'azure_rm_image_id'
-               }
+               } if controller_name != "compute_attributes"
   %>
 </div>


### PR DESCRIPTION
Since `image_id` has now been removed from the `compute_attributes`, so it has to be removed from azurerm too. All other compute attributes had a dependency on image_id inside `new_vm` method which has now been removed in this PR which will correctly reflect the other compute attributes without image_id.