### PR TITLE
Fixes #28772 - OS disk caching should be default ReadWrite

### DIFF
--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -21,10 +21,10 @@ module ForemanAzureRm
                                 ComputeModels::CachingTypes::ReadOnly
                               when 'ReadWrite'
                                 ComputeModels::CachingTypes::ReadWrite
-                              else
-                                # ARM best practices stipulate RW caching on the OS disk
-                                ComputeModels::CachingTypes::ReadWrite
                             end
+                          else
+                            # ARM best practices stipulate RW caching on the OS disk
+                            ComputeModels::CachingTypes::ReadWrite
                           end
         managed_disk_params.storage_account_type = if premium_os_disk == 'true'
                                                      ComputeModels::StorageAccountTypes::PremiumLRS

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -155,10 +155,10 @@
 %>
 
 <%= selectable_f f, :os_disk_caching, %w(None ReadOnly ReadWrite),
-               {},
+               {   :include_blank => _('Please select OS Disk Caching method') },
                {
                    :label    => _('OS Disk Caching'),
-                   :required => true,
+                   :label_help => _("Default ReadWrite"),
                    :class    => "col-md-2"
                }
 %>


### PR DESCRIPTION
As ARM best practices, it is always recommended to keep ReadWrite disk caching method as default. For CLI, this works as expected. Hence, this PR ensures that UI is consistent too. 