### PR TITLE
Fixes #26499 - VM properties widget is overlapping

### DIFF
--- a/app/views/compute_resources_vms/show/_azurerm.html.erb
+++ b/app/views/compute_resources_vms/show/_azurerm.html.erb
@@ -6,20 +6,24 @@
     </thead>
     <tbody>
       <tr>
-        <td>Id</td>
-        <td><%=@vm.id%></td>
+        <td>VM Size</td>
+        <td><%=@vm.vm_size%></td>
       </tr>
       <tr>
         <td>Location</td>
         <td><%=@vm.azure_vm.location%></td>
       </tr>
       <tr>
-        <td>VM Size</td>
-        <td><%=@vm.vm_size%></td>
-      </tr>
-      <tr>
         <td>Platform</td>
         <td><%=@vm.azure_vm.storage_profile.os_disk.os_type%></td>
+      </tr>
+      <tr>
+        <td>Public IP address</td>
+        <td><%=@vm.public_ip_address%></td>
+      </tr>
+      <tr>
+        <td>Private IP address</td>
+        <td><%=@vm.private_ip_address%></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
The ID property which was till now being displayed caused this overlapping. The Azure's vm id is too long to be contained within the vm details column. Upon investigating around other compute resources, it's notable that ID is usually not shown in the hosts or vm details page. Hence, removing the ID and instead adding relevant fields like `public_ip_address` and `private_ip_address` as shown by other CRs too.