### PR TITLE
Fixes #28972 - Migration to fix casing to AzureRm

### DIFF
--- a/db/migrate/20200211073049_fix_case_azure_rm.rb
+++ b/db/migrate/20200211073049_fix_case_azure_rm.rb
@@ -1,0 +1,5 @@
+class FixCaseAzureRm < ActiveRecord::Migration[5.2]
+  def change
+    ComputeResource.where(type: 'ForemanAzureRM::AzureRM').update_all(type: 'ForemanAzureRm::AzureRm')
+  end
+end


### PR DESCRIPTION
For the older compute resource created with `AzureRM` as the provider or `ForemanAzureRM` as the type, it doesn't load the new model that has been renamed in #58 to `AzureRm`. Hence, adding this migration that will handle the issue of Uninitialized constant error.