### PR TITLE
Refs #28972 - Add db/migrate directory to engine

### DIFF
--- a/lib/foreman_azure_rm/engine.rb
+++ b/lib/foreman_azure_rm/engine.rb
@@ -14,6 +14,13 @@ module ForemanAzureRm
       end
     end
 
+    # Add any db migrations
+    initializer "foreman_azure_rm.load_app_instance_data" do |app|
+      ForemanAzureRm::Engine.paths['db/migrate'].existent.each do |path|
+        app.config.paths['db/migrate'] << path
+      end
+    end
+
     initializer "foreman_azure_rm.add_rabl_view_path" do
       Rabl.configure do |config|
         config.view_paths << ForemanAzureRm::Engine.root.join('app', 'views')


### PR DESCRIPTION
This was missing in #73 and hence, added here since the `db/migrate` directory has been newly added in the plugin.