### PR TITLE
Fixes #29167 - Support Multiple NICs

### DIFF
--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -75,7 +75,11 @@ module ForemanAzureRm
         network_interface_card_ids.each_with_index do |id, index|
           nic = ComputeModels::NetworkInterfaceReference.new
           nic.id = id
-          nic.primary = true
+          if index == 0
+            nic.primary = true
+          else
+            nic.primary = false
+          end
           network_interface_cards << nic
         end
         network_profile = ComputeModels::NetworkProfile.new


### PR DESCRIPTION
An Azure VM can now be created with multiple NICs through Foreman but, the number of NICs will depend on the VM Size. Please refer to this [MSFT documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable) for the same.