### PR TITLE
Fixes #29501 - Add Internationalization support

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -1,0 +1,61 @@
+#
+# Makefile for PO merging and MO generation. More info in the README.
+#
+# make all-mo (default) - generate MO files
+# make check - check translations using translate-tool
+# make tx-update - download and merge translations from Transifex
+# make clean - clean everything
+#
+DOMAIN = foreman_azure_rm
+VERSION = $(shell ruby -e 'require "rubygems";spec = Gem::Specification::load(Dir.glob("../*.gemspec")[0]);puts spec.version')
+POTFILE = $(DOMAIN).pot
+MOFILE = $(DOMAIN).mo
+POFILES = $(shell find . -name '$(DOMAIN).po')
+MOFILES = $(patsubst %.po,%.mo,$(POFILES))
+POXFILES = $(patsubst %.po,%.pox,$(POFILES))
+EDITFILES = $(patsubst %.po,%.edit.po,$(POFILES))
+
+%.mo: %.po
+	mkdir -p $(shell dirname $@)/LC_MESSAGES
+	msgfmt -o $(shell dirname $@)/LC_MESSAGES/$(MOFILE) $<
+
+# Generate MO files from PO files
+all-mo: $(MOFILES)
+
+# Check for malformed strings
+%.pox: %.po
+	msgfmt -c $<
+	pofilter --nofuzzy -t variables -t blank -t urls -t emails -t long -t newlines \
+		-t endwhitespace -t endpunc -t puncspacing -t options -t printf -t validchars --gnome $< > $@
+	cat $@
+	! grep -q msgid $@
+
+%.edit.po:
+	touch $@
+
+check: $(POXFILES)
+
+# Unify duplicate translations
+uniq-po:
+	for f in $(shell find ./ -name "*.po") ; do \
+		msguniq $$f -o $$f ; \
+	done
+
+tx-pull: $(EDITFILES)
+	tx pull -f
+	for f in $(EDITFILES) ; do \
+		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
+	done
+
+tx-update: tx-pull
+	@echo
+	@echo Run rake plugin:gettext[$(DOMAIN)] from the Foreman installation, then make -C locale mo-files to finish
+	@echo
+
+mo-files: $(MOFILES)
+	git add $(POFILES) $(POTFILE) ../locale/*/LC_MESSAGES
+	git commit -m "i18n - pulling from tx"
+	@echo
+	@echo Changes commited!
+	@echo
+

--- a/locale/en/foreman_azure_rm.po
+++ b/locale/en/foreman_azure_rm.po
@@ -1,0 +1,171 @@
+# English translations for foreman_azure_rm package.
+# Copyright (C) 2020 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the foreman_azure_rm package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: foreman_azure_rm 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2020-04-08 06:57-0400\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+msgid "%{vm_size} VM Size"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Additional number of disks can be added based on VM Size. For more details, please refer to Microsoft Azure's documentation"
+msgstr ""
+
+msgid "Azure Region"
+msgstr ""
+
+msgid "Azure Resource Manager as a compute resource for Foreman"
+msgstr ""
+
+msgid "Azure Subnet"
+msgstr ""
+
+msgid "Azure's Default"
+msgstr ""
+
+msgid "Azure's default"
+msgstr ""
+
+msgid "Client ID"
+msgstr ""
+
+msgid "Client ID for AzureRm"
+msgstr ""
+
+msgid "Client Secret"
+msgstr ""
+
+msgid "Client Secret for AzureRm"
+msgstr ""
+
+msgid "Comma seperated file URIs"
+msgstr ""
+
+msgid "Custom Script Command"
+msgstr ""
+
+msgid "Data Disk Caching"
+msgstr ""
+
+msgid "Default ReadWrite"
+msgstr ""
+
+msgid "Does this image support user data input?"
+msgstr ""
+
+msgid "Image"
+msgstr ""
+
+msgid "Marketplace Image URN"
+msgstr ""
+
+msgid "Marketplace URN (e.g. OpenLogic:CentOS:7.5:latest)"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "OS Disk Caching"
+msgstr ""
+
+msgid "Password"
+msgstr ""
+
+msgid "Password to authenticate with - used for SSH finish step."
+msgstr ""
+
+msgid "Platform"
+msgstr ""
+
+msgid "Please select a Resource Group"
+msgstr ""
+
+msgid "Please select a VM Size"
+msgstr ""
+
+msgid "Please select an image"
+msgstr ""
+
+msgid "Premium OS Disk"
+msgstr ""
+
+msgid "Properties"
+msgstr ""
+
+msgid "Public IP"
+msgstr ""
+
+msgid "Region"
+msgstr ""
+
+msgid "Reload Images, Sizes, vNets"
+msgstr ""
+
+msgid "Resource Group"
+msgstr ""
+
+msgid "SSH Key"
+msgstr ""
+
+msgid "Select"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
+msgid "Size (GB)"
+msgstr ""
+
+msgid "Some of the listed regions might not be supported for your subscription. Please verify on Azure portal."
+msgstr ""
+
+msgid "State"
+msgstr ""
+
+msgid "Static Private IP"
+msgstr ""
+
+msgid "Subscription ID"
+msgstr ""
+
+msgid "Subscription ID for AzureRm"
+msgstr ""
+
+msgid "Tenant ID"
+msgstr ""
+
+msgid "The region you selected has no sizes associated with it"
+msgstr ""
+
+msgid "The selected image has no associated compute resource"
+msgstr ""
+
+msgid "The selected region has no subnets"
+msgstr ""
+
+msgid "The user that will be used to SSH into the VM for completion"
+msgstr ""
+
+msgid "To perform commands as root, prefix it with 'sudo'"
+msgstr ""
+
+msgid "Username"
+msgstr ""
+
+msgid "VM Size"
+msgstr ""

--- a/locale/foreman_azure_rm.pot
+++ b/locale/foreman_azure_rm.pot
@@ -1,0 +1,234 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the foreman_azure_rm package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: foreman_azure_rm 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-04-08 06:57-0400\n"
+"PO-Revision-Date: 2020-04-08 06:57-0400\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#:
+#: ../app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb:10
+msgid "Client ID for AzureRm"
+msgstr ""
+
+#:
+#: ../app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb:11
+msgid "Client Secret for AzureRm"
+msgstr ""
+
+#:
+#: ../app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb:12
+msgid "Subscription ID for AzureRm"
+msgstr ""
+
+#:
+#: ../app/controllers/foreman_azure_rm/concerns/hosts_controller_extensions.rb:11
+msgid "The region you selected has no sizes associated with it"
+msgstr ""
+
+#:
+#: ../app/controllers/foreman_azure_rm/concerns/hosts_controller_extensions.rb:23
+msgid "The selected region has no subnets"
+msgstr ""
+
+#:
+#: ../app/controllers/foreman_azure_rm/concerns/hosts_controller_extensions.rb:27
+msgid "The selected image has no associated compute resource"
+msgstr ""
+
+#: ../app/models/foreman_azure_rm/azure_rm_compute.rb:148
+msgid "%{vm_size} VM Size"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_azurerm.html.erb:1
+msgid "Client ID"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_azurerm.html.erb:2
+msgid "Client Secret"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_azurerm.html.erb:3
+msgid "Subscription ID"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_azurerm.html.erb:4
+msgid "Tenant ID"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_azurerm.html.erb:6
+msgid "Azure Region"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_azurerm.html.erb:6
+msgid ""
+"Some of the listed regions might not be supported for your subscription. Pleas"
+"e verify on Azure portal."
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:91
+msgid "Please select a Resource Group"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:94
+#: ../app/views/compute_resources_vms/index/_azurerm.html.erb:6
+msgid "Resource Group"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:97
+msgid "Reload Images, Sizes, vNets"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:109
+msgid "Please select a VM Size"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:111
+msgid "VM Size"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:120
+msgid "Platform"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:127
+msgid "Username"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:134
+msgid "Password"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:144
+msgid "SSH Key"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:150
+msgid "Premium OS Disk"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:158
+msgid "Azure's Default"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:160
+msgid "OS Disk Caching"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:161
+msgid "Default ReadWrite"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:168
+msgid "Custom Script Command"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:169
+msgid "To perform commands as root, prefix it with 'sudo'"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:175
+msgid "Comma seperated file URIs"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:181
+msgid "Please select an image"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_base.html.erb:184
+msgid "Image"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_network.html.erb:5
+msgid "Select"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_network.html.erb:7
+msgid "Azure Subnet"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_network.html.erb:18
+msgid "Public IP"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_network.html.erb:25
+msgid "Static Private IP"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_volume.html.erb:4
+msgid "Size (GB)"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_volume.html.erb:8
+msgid ""
+"Additional number of disks can be added based on VM Size. For more details, pl"
+"ease refer to Microsoft Azure's documentation"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_volume.html.erb:14
+msgid "Azure's default"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/azurerm/_volume.html.erb:17
+msgid "Data Disk Caching"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/index/_azurerm.html.erb:4
+msgid "Name"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/index/_azurerm.html.erb:5
+msgid "Size"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/index/_azurerm.html.erb:7
+msgid "Region"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/index/_azurerm.html.erb:8
+msgid "State"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/index/_azurerm.html.erb:9
+msgid "Actions"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/show/_azurerm.html.erb:5
+msgid "Properties"
+msgstr ""
+
+#: ../app/views/images/form/_azurerm.html.erb:2
+msgid "The user that will be used to SSH into the VM for completion"
+msgstr ""
+
+#: ../app/views/images/form/_azurerm.html.erb:4
+msgid "Password to authenticate with - used for SSH finish step."
+msgstr ""
+
+#: ../app/views/images/form/_azurerm.html.erb:5
+msgid "Marketplace Image URN"
+msgstr ""
+
+#: ../app/views/images/form/_azurerm.html.erb:5
+msgid "Marketplace URN (e.g. OpenLogic:CentOS:7.5:latest)"
+msgstr ""
+
+#: ../app/views/images/form/_azurerm.html.erb:6
+msgid "Does this image support user data input?"
+msgstr ""
+
+#: gemspec.rb:2
+msgid "Azure Resource Manager as a compute resource for Foreman"
+msgstr ""


### PR DESCRIPTION
These changes adds required files, commands to export new strings in pot files and keep those in sync with transifex.