### PR TITLE
Fixes #29819 - Support byos images on azurerm

### DIFF
--- a/app/views/images/form/_azurerm.html.erb
+++ b/app/views/images/form/_azurerm.html.erb
@@ -2,5 +2,5 @@
            :help_inline         => _("The user that will be used to SSH into the VM for completion")
 %>
 <%= password_f f, :password, :keep_value => true, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
-<%= image_field(f, :label => _("Azure Image Name"), :help_inline => _("For custom or shared gallery image prefix the uuid with 'custom://' or 'gallery://'. For public image, prefix the uuid with 'marketplace://'.' (e.g. 'marketplace://OpenLogic:CentOS:7.5:latest' or 'custom://image-name')")) %>
+<%= image_field(f, :label => _("Azure Image Name"), :help_inline => _("For custom or shared gallery image, use prefix 'custom://' or 'gallery://'. For public and RHEL-byos images, prefix the uuid with 'marketplace://'. (e.g. 'marketplace://OpenLogic:CentOS:7.5:latest' or 'custom://image-name')")) %>
 <%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input?") %>

--- a/lib/foreman_azure_rm/engine.rb
+++ b/lib/foreman_azure_rm/engine.rb
@@ -42,7 +42,7 @@ module ForemanAzureRm
       require 'azure_mgmt_subscriptions'
 
       # Add format validation for azure images
-      ::Image.validates :uuid, format: { with: /\A((marketplace|custom|gallery):\/\/)[^:]+(:[^:]+:[^:]+:[^:]+)?\z/,
+      ::Image.validates :uuid, uniqueness: { scope: :compute_resource_id, case_sensitive: false }, format: { with: /\A((marketplace|custom|gallery):\/\/)[^:]+(:[^:]+:[^:]+:[^:]+)?\z/,
           message: "Incorrect UUID format" }, if: -> (image){ image.compute_resource.is_a? ForemanAzureRm::AzureRm }
 
       # Use excon as default so that HTTP Proxy settings of foreman works


### PR DESCRIPTION
BYOS images on azure are a different type of marketplace images. They just need an added parameter from `PurchasePlan` class of the sdk. This PR provisions the host using rhel byos image if the image terms have been accepted. Refer the [MSFT doc](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/redhat/byos#requirements-and-conditions-to-access-the-red-hat-gold-images) to accept image terms.
Currently, I have to test if with this change the already supported images still function correctly or not hence, adding WIP label.  Will remove the label once verified that it works smoothly for every single image category.