### PR TITLE
Add support for gov-cloud (fixes #96)

### DIFF
--- a/app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb
+++ b/app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb
@@ -10,6 +10,7 @@ module ForemanAzureRm
           param :app_ident, String, :desc => N_("Client ID for AzureRm")
           param :secret_key, String, :desc => N_("Client Secret for AzureRm")
           param :sub_id, String, :desc => N_("Subscription ID for AzureRm")
+          param :cloud, String, :desc => N_("Cloud")
         end
       end
 

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -11,6 +11,7 @@ module ForemanAzureRm
     alias_attribute :secret_key, :password
     alias_attribute :region, :url
     alias_attribute :tenant, :uuid
+    alias_attribute :azure_environment, :cloud
 
     validates :user, :password, :uuid, :app_ident, :presence => true
 
@@ -41,8 +42,16 @@ module ForemanAzureRm
       attrs[:app_ident] = name
     end
 
+    def cloud
+      attrs[:cloud]
+    end
+
+    def cloud=(name)
+      attrs[:cloud] = name
+    end
+
     def sdk
-      @sdk ||= ForemanAzureRm::AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id)
+      @sdk ||= ForemanAzureRm::AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id, azure_environment)
     end
     
     def to_label
@@ -81,7 +90,7 @@ module ForemanAzureRm
 
     def test_connection(options = {})
       super
-      errors[:user].empty? && errors[:password].empty? && errors[:uuid].empty? && errors[:app_ident].empty? && regions
+      errors[:user].empty? && errors[:password].empty? && errors[:uuid].empty? && errors[:app_ident].empty? && errors[:cloud].empty? && regions
     rescue StandardError => e
       errors[:base] << e.message
     rescue Excon::Error::Socket => e

--- a/app/views/api/v2/compute_resources/azurerm.json.rabl
+++ b/app/views/api/v2/compute_resources/azurerm.json.rabl
@@ -1,1 +1,1 @@
-attributes :tenant, :app_ident, :sub_id, :secret_key, :region
+attributes :azure_environment, :tenant, :app_ident, :sub_id, :secret_key, :region

--- a/app/views/compute_resources/form/_azurerm.html.erb
+++ b/app/views/compute_resources/form/_azurerm.html.erb
@@ -1,3 +1,9 @@
+<%= selectable_f f, :cloud, [
+  ['Public / Standard', 'azure'],  
+  ['US Government', 'azureusgovernment'],
+  ['China', 'azurechina'],
+  ['Germany', 'azuregermancloud'],
+], {}, { :label => _('Cloud'), :required => true } %>
 <%= text_f f, :app_ident, :label => _('Client ID'), :required => true %>
 <%= password_f f, :password, :label => _('Client Secret'), :keep_value => true, :required => true %>
 <%= text_f f, :user, :label => _('Subscription ID'), :required => true %>

--- a/foreman_azure_rm.gemspec
+++ b/foreman_azure_rm.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.description = 'This gem provides Azure Resource Manager as a compute resource for The Foreman'
 
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'azure_mgmt_resources', '~> 0.17.6'
-  s.add_dependency 'azure_mgmt_network', '~> 0.19.0'
-  s.add_dependency 'azure_mgmt_storage', '~> 0.17.10'
-  s.add_dependency 'azure_mgmt_compute', '~> 0.18.7'
-  s.add_dependency 'azure_mgmt_subscriptions', '~> 0.18.1'
+  s.add_dependency 'azure_mgmt_resources', '~> 0.17.9'
+  s.add_dependency 'azure_mgmt_network', '~> 0.23.4'
+  s.add_dependency 'azure_mgmt_storage', '~> 0.21.1'
+  s.add_dependency 'azure_mgmt_compute', '~> 0.19.3'
+  s.add_dependency 'azure_mgmt_subscriptions', '~> 0.18.4'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'mocha', '~> 1.2', '>= 1.2.1'
 end

--- a/lib/foreman_azure_rm/engine.rb
+++ b/lib/foreman_azure_rm/engine.rb
@@ -11,7 +11,7 @@ module ForemanAzureRm
       Foreman::Plugin.register :foreman_azure_rm do
         requires_foreman '>= 1.17'
         compute_resource ForemanAzureRm::AzureRm
-        parameter_filter ComputeResource, :azure_vm, :tenant, :app_ident, :secret_key, :sub_id, :region
+        parameter_filter ComputeResource, :azure_vm, :tenant, :app_ident, :secret_key, :sub_id, :region, :cloud
       end
     end
 

--- a/test/factories/azure.rb
+++ b/test/factories/azure.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     add_attribute(:app_ident) { '33333333-3333-3333-3333-333333333333' }
     add_attribute(:uuid) { '44444444-4444-4444-4444-444444444444' }
     add_attribute(:url) { 'eastus' }
+    add_attribute(:cloud) { 'azure' }
   end
 end

--- a/test/unit/azure_sdk_adapter_test.rb
+++ b/test/unit/azure_sdk_adapter_test.rb
@@ -8,7 +8,8 @@ module ForemanAzureRm
       app_ident        = compute_resource.app_ident
       secret_key       = compute_resource.password
       sub_id           = compute_resource.user
-      @test_adapter    = AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id)
+      cloud            = compute_resource.cloud
+      @test_adapter    = AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id, cloud)
       AzureSdkAdapter.stubs(:gallery_caching).with('test_rg').returns({})
     end
 


### PR DESCRIPTION
This adds a new preference to select which cloud environment to target.
Endpoint URLs for additonal clouds are taking from MS documentation.
All calls to cloud API's now check the cloud preference and select
the correct endpoint for the current environment.