### PR TITLE
Refs #31837 - fix syntax error in azurerm.html.erb

### DIFF
--- a/app/views/compute_resources/form/_azurerm.html.erb
+++ b/app/views/compute_resources/form/_azurerm.html.erb
@@ -4,7 +4,7 @@
   ['China', 'azurechina'],
   ['Germany', 'azuregermancloud'],
 ], {}, { :label => _('Cloud'), :required => true } %>
-<%= text_f f, :app_ident, :label => _('Client ID'), :required => true :help_inline => link_to(icon_text('help', _('Documentation'), :kind => 'pficon'),
+<%= text_f f, :app_ident, :label => _('Client ID'), :required => true, :help_inline => link_to(icon_text('help', _('Documentation'), :kind => 'pficon'),
   azure_doc_url, :rel => 'external', :class => 'btn btn-default btn-docs', :target => '_blank') %>
 <%= password_f f, :password, :label => _('Client Secret'), :keep_value => true, :required => true %>
 <%= text_f f, :user, :label => _('Subscription ID'), :required => true %>


### PR DESCRIPTION
When loading up the plugin to work on my next bug I hit a syntax error where the form would not load up correctly, looks like I missed a comma when doing the rebase.