### PR TITLE
Drop deface dependency

### DIFF
--- a/foreman_azure_rm.gemspec
+++ b/foreman_azure_rm.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.files   = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.description = 'This gem provides Azure Resource Manager as a compute resource for The Foreman'
 
-  s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'azure_mgmt_resources', '~> 0.17.9'
   s.add_dependency 'azure_mgmt_network', '~> 0.23.4'
   s.add_dependency 'azure_mgmt_storage', '~> 0.21.1'


### PR DESCRIPTION
9a44eb2f85af933321a083df2f68d2162526e00f dropped the last use of Deface and is no longer used.