### PR TITLE
Refs #31837 - Update docs button to use Foreman plugin helper

### DIFF
--- a/app/helpers/azure_compute_resource_helper.rb
+++ b/app/helpers/azure_compute_resource_helper.rb
@@ -10,8 +10,7 @@ module AzureComputeResourceHelper
     end
     selectable_f(f, :url, regions, {}, {:label => _('Azure Region'), :disabled => regions.empty?, :required => true, :help_inline_permanent => load_button_f(f, regions.present?, _("Load Regions")) })
   end
-  def azure_doc_url
+  def azure_doc_version
     doc_version = Foreman::Plugin.find(:foreman_azure_rm).version.scan(/\d+\.\d+/).first + '.x'
-    "https://theforeman.org/plugins/foreman_azure/#{doc_version}"
   end
 end

--- a/app/views/compute_resources/form/_azurerm.html.erb
+++ b/app/views/compute_resources/form/_azurerm.html.erb
@@ -4,8 +4,7 @@
   ['China', 'azurechina'],
   ['Germany', 'azuregermancloud'],
 ], {}, { :label => _('Cloud'), :required => true } %>
-<%= text_f f, :app_ident, :label => _('Client ID'), :required => true, :help_inline => link_to(icon_text('help', _('Documentation'), :kind => 'pficon'),
-  azure_doc_url, :rel => 'external', :class => 'btn btn-default btn-docs', :target => '_blank') %>
+<%= text_f f, :app_ident, :label => _('Client ID'), :required => true, :help_inline => link_to('Documentation', external_link_path(type: 'plugin_manual', name: 'foreman_azure', version: azure_doc_version), :kind => 'pficon', :rel => 'external', :class => 'btn btn-default btn-docs', :target => '_blank') %>
 <%= password_f f, :password, :label => _('Client Secret'), :keep_value => true, :required => true %>
 <%= text_f f, :user, :label => _('Subscription ID'), :required => true %>
 <%= text_f f, :uuid, :label => _('Tenant ID'), :required => true %>


### PR DESCRIPTION
@ShimShtein 

How does this look? I was able to adapt my method to return the version still so we can use that. Right now, it goes to a 404 since I need to make a docs pr for 2.2 but it's going to the right place now and it should let me do for your downstream to make it work. 

Here is the docs PR to fix the 404:

https://github.com/theforeman/theforeman.org/pull/1799