### PR TITLE
Fixes #32500 - Use Foreman::Cast.to_bool to parse private_ip

### DIFF
--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -123,7 +123,7 @@ module ForemanAzureRm
       def create_nics(region, args = {})
         nics               = []
         args[:interfaces_attributes].each do |nic, attrs|
-          private_ip = (attrs[:private_ip] == 'false') ? false : true
+          private_ip = Foreman::Cast.to_bool(attrs[:private_ip])
           priv_ip_alloc       = if private_ip
                                   NetworkModels::IPAllocationMethod::Static
                                 else


### PR DESCRIPTION
This allows private_ip to be String, Integer or Boolean, making it much
easier for users to submit the right value.