### PR TITLE
Fixes #32555 - default to the public "azure" cloud if not specified

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -43,7 +43,7 @@ module ForemanAzureRm
     end
 
     def cloud
-      attrs[:cloud]
+      attrs[:cloud] || 'azure'
     end
 
     def cloud=(name)


### PR DESCRIPTION
this makes older API clients work without changes