### PR TITLE
Fixes #32561 - use "cloud" in the CR API output

### DIFF
--- a/app/views/api/v2/compute_resources/azurerm.json.rabl
+++ b/app/views/api/v2/compute_resources/azurerm.json.rabl
@@ -1,1 +1,1 @@
-attributes :azure_environment, :tenant, :app_ident, :sub_id, :region
+attributes :cloud, :tenant, :app_ident, :sub_id, :region


### PR DESCRIPTION
"cloud" is the parameter we expect the user to enter, so let's also use
it for our output