### PR TITLE
don't include sub_id in api parameters

### DIFF
--- a/app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb
+++ b/app/controllers/foreman_azure_rm/concerns/compute_resources_controller_extensions.rb
@@ -9,7 +9,6 @@ module ForemanAzureRm
           # Not adding :tenant as already specified in core.
           param :app_ident, String, :desc => N_("Client ID for AzureRm")
           param :secret_key, String, :desc => N_("Client Secret for AzureRm")
-          param :sub_id, String, :desc => N_("Subscription ID for AzureRm")
           param :cloud, String, :desc => N_("Cloud")
         end
       end

--- a/app/views/api/v2/compute_resources/azurerm.json.rabl
+++ b/app/views/api/v2/compute_resources/azurerm.json.rabl
@@ -1,1 +1,1 @@
-attributes :cloud, :tenant, :app_ident, :sub_id, :region
+attributes :cloud, :tenant, :app_ident, :region, :user


### PR DESCRIPTION
we alias this to user in models/foreman_azure_rm/azure_rm.rb:

    alias_attribute :sub_id, :user

and it feels more natural to use "user" instead of the subscription id

this will most probably require changes to hammer and docs, so please review carefully :)