### PR TITLE
Fixes ##32640 - Implement Azure Extension Microsoft.HpcCompute/NvidiaGpuDriver{Linux,…Windows}/1.3 to deploy NVIDIA GPU drivers

### DIFF
--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -281,19 +281,20 @@ module ForemanAzureRm
         case args[:platform]
         # https://docs.microsoft.com/fr-fr/azure/virtual-machines/extensions/hpccompute-gpu-linux
         when 'Linux'
-          extension.virtual_machine_extension_type = 'NvidiaGpuDriverLinux'
+          extension_name = 'NvidiaGpuDriverLinux'
         # https://docs.microsoft.com/fr-fr/azure/virtual-machines/extensions/hpccompute-gpu-windows
         when 'Windows'
-          extension.virtual_machine_extension_type = 'NvidiaGpuDriverWindows'
+          extension_name = 'NvidiaGpuDriverWindows'
         else
           raise RuntimeError, "Unsupported platform #{args[:platform]}"
         end
+        extension.virtual_machine_extension_type = extension_name
 
         extension_for_log = "#{extension.publisher}/#{extension.virtual_machine_extension_type}/#{extension.type_handler_version}"
         Foreman::Logging.logger('app').info "Azure RM machine #{args[:name]}: creating #{extension_for_log} extension"
         sdk.create_or_update_vm_extensions(args[:resource_group],
                                            args[:vm_name],
-                                           'ForemanNvidiaGpuDriver',
+                                           extension_name,
                                            extension)
       end
 

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -225,7 +225,7 @@ module ForemanAzureRm
       @vm_nvidia_gpu_extension ||= begin
         @azure_vm.resources.each do |ext|
           ext_name = ext.id.split('/')[-1]
-          next unless ext_name == 'ForemanNvidiaGpuDriver'
+          next unless ['NvidiaGpuDriverLinux', 'NvidiaGpuDriverWindows'].include? ext_name
           return sdk.get_vm_extension(@azure_vm.resource_group, name, ext_name)
         end
         nil

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -185,6 +185,16 @@
          }
 %>
 
+<%= checkbox_f f, :nvidia_gpu_extension,
+         {
+              :label => _('NVIDIA driver / CUDA'),
+              :label_size => "col-md-2",
+              :label_help => _("Deploy NVIDIA GPU driver and CUDA (Azure Extension Microsoft.HpcCompute/NvidiaGpuDriver{Linux,Windows}/1.3)"),
+         },
+         'true',
+         'false'
+%>
+
 <div id="image_selection">
   <%= select_f f, :image_id, images, :uuid, :name,
                { :include_blank => (images.empty? or images.size == 1) ? false : _('Please select an image') },


### PR DESCRIPTION
Everything is in the title :)

I'm not sure it actually works on Linux but the extension is available so I made it available as well.
Both are set using a checkbox from foreman interface and actual state is read when displaying existing VM. It can also be saved in compute profiles.

I still need to check it's working using REST API but I think it should.