### PR TITLE
Fixes #32713 - Add Cloud validation to controller

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -59,12 +59,21 @@ module ForemanAzureRm
     end
 
     def ensure_attributes_and_values
-      validate_region
+      validate_region if validate_cloud?
     end
 
     def validate_region
       return unless regions.present?
       errors.add(:region, "is not valid, must be lowercase eg. 'eastus'. No special characters allowed.") unless regions.collect(&:second).include?(region)
+    end
+
+    def validate_cloud?
+      valid_clouds = ['azure', 'azureusgovernment', 'azurechina', 'azuregermancloud']
+      unless valid_clouds.include?(cloud)
+      	errors.add(:cloud, "is not valid. Valid choices are #{valid_clouds.join(", ")}.")
+	      return false
+      end
+      true
     end
 
     def self.model_name

--- a/test/unit/azure_rm_test.rb
+++ b/test/unit/azure_rm_test.rb
@@ -23,6 +23,13 @@ module ForemanAzureRm
       assert_equal [['East US', 'eastus'], ['West US', 'westus']], @azure_cr.regions
     end
 
+    test "list valid standard cloud name" do
+      cloud = %w[azure azureusgovernment azurechina azuregermancloud].sample
+      ForemanAzureRm::AzureRm.any_instance.stubs(:validate_cloud?).returns(true)
+      @azure_cr.cloud=(cloud)
+      assert @azure_cr.validate_cloud?
+    end
+
     test "list all resource groups" do
       mock_resource_client = mock('mock_resource_client')
       @mock_sdk.stubs(:resource_client).returns(mock_resource_client)


### PR DESCRIPTION
Before:
```bash
[vagrant@hammer ~]$ hammer compute-resource create --name="food1" --secret-key="xxxxx" --location-id 2 --organization-id 1 --provider AzureRm --app-ident="xxxx" --sub-id="xxxx" --tenant="xxxxx" --region="eastus" --cloud="pizza"
Could not create the compute resource:
Internal Server Error: the server was unable to finish the request. This may be caused by unavailability of some required service, incorrect API call or a server-side bug. There may be more information in the server's logs.
```
After:
```bash
[vagrant@hammer ~]$ hammer -d compute-resource create --name="food2" --secret-key="xxxxxx" --location-id 2 --organization-id 1 --provider AzureRm --app-ident="xxxxx" --sub-id="xxxxxx" --tenant="xxxxx" --region="eastus" --cloud="pizza"
Could not create the compute resource:
  Cloud is not valid. Valid choices are azure, azureusgovernment, azurechina, azuregermancloud.
```