### PR TITLE
fixes #33159 - Add support for tags on Azure VM resources

### DIFF
--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -176,6 +176,14 @@ module ForemanAzureRm
         logger.debug msg
         vm_create_params = ComputeModels::VirtualMachine.new.tap do |vm|
           vm.location = vm_hash[:location]
+          vm.tags = {}
+          unless vm_hash[:tags].nil?
+            arr = vm_hash[:tags].split(',')
+            arr.each do |item|
+              kv = item.split('=')
+              vm.tags[kv[0].strip] = kv[1].strip
+            end            
+          end
           unless vm_hash[:availability_set_id].nil?
             sub_resource = MsRestAzure::SubResource.new
             sub_resource.id = vm_hash[:availability_set_id]

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -330,6 +330,7 @@ module ForemanAzureRm
         script_command:                  args[:script_command],
         script_uris:                     args[:script_uris],
         nvidia_gpu_extension:            args[:nvidia_gpu_extension],
+        tags:                            args[:tags],
       )
       logger.debug "Virtual Machine #{args[:vm_name]} Created Successfully."
       # request NVIDIA GPU driver and CUDA stack
@@ -348,6 +349,7 @@ module ForemanAzureRm
         script_command: user_command,
         script_uris: args[:script_uris],
         nvidia_gpu_extension: Foreman::Cast.to_bool(args[:nvidia_gpu_extension]),
+        tags: args[:tags],
       )
     rescue RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -7,6 +7,7 @@ module ForemanAzureRm
     attr_accessor :script_command, :script_uris
     attr_accessor :nvidia_gpu_extension
     attr_accessor :volumes
+    attr_accessor :tags
 
     delegate :name, to: :azure_vm, allow_nil: true
 
@@ -17,7 +18,8 @@ module ForemanAzureRm
                    volumes: [],
                    script_command: nil,
                    script_uris: nil,
-                   nvidia_gpu_extension: false)
+                   nvidia_gpu_extension: false,
+                   tags: [])
 
       @azure_vm = azure_vm
       @sdk = sdk
@@ -27,6 +29,7 @@ module ForemanAzureRm
       @script_command ||= script_command
       @script_uris ||= script_uris
       @nvidia_gpu_extension ||= nvidia_gpu_extension
+      @tags ||= tags
       @azure_vm.hardware_profile ||= ComputeModels::HardwareProfile.new
       @azure_vm.os_profile ||= ComputeModels::OSProfile.new
       @azure_vm.os_profile.linux_configuration ||= ComputeModels::LinuxConfiguration.new

--- a/app/views/compute_resources_vms/form/azurerm/_base.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_base.html.erb
@@ -185,6 +185,13 @@
          }
 %>
 
+<%= text_f f, :tags,
+         {
+             :label => _('Azure Tags'),
+             :label_help => _('Comma seperated list of name=value pairs for tags on this VM in Azure')
+         }
+%>
+
 <%= checkbox_f f, :nvidia_gpu_extension,
          {
               :label => _('NVIDIA driver / CUDA'),


### PR DESCRIPTION
Add support for tagging newly create VM's with name1=value1,name2=value2 syntax on the Virtual Machine tab.