### PR TITLE
Fixes #35481 - Remove hard coded sudo command in script extension

### DIFF
--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -291,16 +291,10 @@ module ForemanAzureRm
 
       if args[:platform] == 'Linux'
         if args[:password].present? && !args[:ssh_key_data].present?
-          # Any change to sudoers_cmd and formation of new
-          # args[:script_command] must be accordingly changed
-          # in script_command method in AzureRmCompute class
-          sudoers_cmd = "$echo #{args[:password]} | sudo -S echo '\"#{args[:username]}\" ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/waagent"
           if args[:script_command].present?
             # to run the script_cmd given through form as username
             user_command = args[:script_command]
-            args[:script_command] =  sudoers_cmd + " ; su - \"#{args[:username]}\" -c \"#{user_command}\""
-          else
-            args[:script_command] =  sudoers_cmd
+            args[:script_command] = "su - \"#{args[:username]}\" -c \"#{user_command}\""
           end
           disable_password_auth = false
         elsif args[:ssh_key_data].present? && !args[:password].present?

--- a/test/unit/azure_rm_test.rb
+++ b/test/unit/azure_rm_test.rb
@@ -46,11 +46,6 @@ module ForemanAzureRm
       test "create vm with password and without custom data" do
         @mock_vm.stubs(:disable_password_authentication).returns(false)
         @mock_vm.os_profile.stubs(:custom_data)
-        mock_vm_extension = mock('mock_vm_extension')
-        @mock_sdk.expects(:create_or_update_vm_extensions).with() do |actual_rg, vm_name, script_name, actual_ext|
-          actual_rg == "rg1" &&
-          actual_ext.settings["commandToExecute"] == "$echo testpswd123 | sudo -S echo '\"testuser\" ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/waagent"
-        end.returns(mock_vm_extension)
         mock_create_or_update_vm_with_password
         vm_args = base_vm_args.merge(with_password_auth).merge(with_marketplace_image)
         actual_server = @azure_cr.create_vm(vm_args)
@@ -70,7 +65,7 @@ module ForemanAzureRm
         mock_vm_extension = mock('mock_vm_extension')
         @mock_sdk.expects(:create_or_update_vm_extensions).with() do |actual_rg, vm_name, script_name, actual_ext|
           actual_rg == "rg1" &&
-          actual_ext.settings["commandToExecute"] == "$echo testpswd123 | sudo -S echo '\"testuser\" ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/waagent ; su - \"testuser\" -c \"sudo sh /var/lib/waagent/custom-script/download/0/myscript.sh\"" &&
+          actual_ext.settings["commandToExecute"] == "su - \"testuser\" -c \"sudo sh /var/lib/waagent/custom-script/download/0/myscript.sh\"" &&
           actual_ext.settings["fileUris"] == ["https://gist.githubusercontent.com/apuntamb/f4e9ff4e2daf62bc847313b0c64e59f9/raw/73578e1bb7b03237ae1ac6b787b08d00d126adf0/myscript.sh"]
         end.returns(mock_vm_extension)
         vm_args = base_vm_args.merge(with_password_auth).merge(with_custom_data).merge(with_marketplace_image).merge(with_vm_extensions)
@@ -136,11 +131,6 @@ module ForemanAzureRm
         @mock_vm.storage_profile.image_reference.stubs(:id).returns('/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/galleries/first_gallery/images/first_gallery_img')
         @mock_sdk.stubs(:list_custom_images).returns([])
         mock_create_or_update_vm_with_password
-        mock_vm_extension = mock('mock_vm_extension')
-        @mock_sdk.expects(:create_or_update_vm_extensions).with() do |actual_rg, vm_name, script_name, actual_ext|
-          actual_rg == "rg1" &&
-          actual_ext.settings["commandToExecute"] == "$echo testpswd123 | sudo -S echo '\"testuser\" ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/waagent"
-        end.returns(mock_vm_extension)
         vm_args = base_vm_args.merge(with_password_auth).merge(with_gallery_image)
         actual_server = @azure_cr.create_vm(vm_args)
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When building a VM with Forman in Microsoft Azure, it looks like we hard coded adding `azureuser ALL=(ALL) NOPASSWD:ALL` in the `/etc/sudoers.d/waagent` file This no longer is needed since Azure drops in a `90-cloud-init-users` in a newly provisioned VM. We can see the contents of that file here:
```bash
[root@Toledo123 ~]# cat /etc/sudoers.d/90-cloud-init-users 
# Created by cloud-init v. 19.4 on Tue, 03 Aug 2021 14:30:54 +0000

# User rules for azureuser
azureuser ALL=(ALL) NOPASSWD:ALL

# User rules for azureuser
azureuser ALL=(ALL) NOPASSWD:ALL
```

The hard-coded value actually introduced another bug, we were trying to echo that sudo command even if a user didn't put anything in the `script_command` or `script_uri` fields, which would then add the Linux Script VM Extension to the VM when a user didn't ask for it.

This PR does two things:

* Remove the hardcoded script command so that if a user does not pass anything into `script_command` and `script_uri` we do not create the VM extension for that VM.
* The sudo command was not working so if a user did put in a `script_command` and `script_uri` the command would fail inside the script.

#### Considerations taken when implementing this change?

* Tested on Foreman develop - No regressions
* Tested on Satellite 6.12 - No regressions
* Tested on Satellite 6.11 - No regressions

#### What are the testing steps for this pull request?

* Check out PR
* Create a VM and do not put anything in `script_command` and `script_uri`  and verify VM got created without the Linux Script extension
* Create a vm and use the following for the script commands
  * `script_uris` = https://raw.githubusercontent.com/SatelliteQE/robottelo/master/tests/foreman/data/uri.sh
  * `script_command` = `sudo sh /var/lib/waagent/custom-script/download/0/uri.sh`
* Verify you can see `Hello!` in `/var/tmp/hello.txt.`