### PR TITLE
Unify casing in options

### DIFF
--- a/app/views/compute_resources_vms/form/azurerm/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/azurerm/_volume.html.erb
@@ -11,7 +11,7 @@
 
 <%= selectable_f f, :data_disk_caching, options_for_select(["None", "ReadOnly", "ReadWrite"],
                     :selected => f.object.data_disk_caching || f.object.disk.caching),
-                 { :include_blank => _("Azure's default") },
+                 { :include_blank => _("Azure's Default") },
                  {
                      :class    => "col-md-2",
                      :label    => _('Data Disk Caching'),


### PR DESCRIPTION
This matches the asing with the rest of the context. It also aligns with the other place where it's used (`form/azurerm/_base.html.erb`), which removes one translatable string.