### PR TITLE
Replace retired Azure SDK with direct REST API calls

### DIFF
--- a/app/lib/foreman_azure_rm/azure_async_poller.rb
+++ b/app/lib/foreman_azure_rm/azure_async_poller.rb
@@ -14,9 +14,9 @@ module ForemanAzureRm
       location_url = response.header('Location')
       return nil unless async_url || location_url
 
-      deadline = Time.zone.now + MAX_POLL_SECONDS
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + MAX_POLL_SECONDS
       last_response = response
-      while Time.zone.now < deadline
+      while Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
         interval = last_response.header('Retry-After')&.to_i || DEFAULT_POLL_INTERVAL
         sleep interval
 

--- a/app/lib/foreman_azure_rm/azure_async_poller.rb
+++ b/app/lib/foreman_azure_rm/azure_async_poller.rb
@@ -1,0 +1,71 @@
+require 'json'
+
+module ForemanAzureRm
+  class AzureAsyncPoller
+    MAX_POLL_SECONDS = 1800
+    DEFAULT_POLL_INTERVAL = 5
+
+    def initialize(&authenticated_get)
+      @authenticated_get = authenticated_get
+    end
+
+    def poll(response, resource_url:, method: :put)
+      async_url = response.header('Azure-AsyncOperation')
+      location_url = response.header('Location')
+      return nil unless async_url || location_url
+
+      deadline = Time.now + MAX_POLL_SECONDS
+      last_response = response
+      while Time.now < deadline
+        interval = (last_response.header('Retry-After')&.to_i || DEFAULT_POLL_INTERVAL)
+        sleep interval
+
+        poll_url = async_url || location_url
+        last_response = @authenticated_get.call(poll_url)
+
+        if async_url
+          handle_async_operation_poll(last_response, resource_url, method)&.tap { |result| return result }
+        else
+          handle_location_poll(last_response)&.tap { |result| return result }
+        end
+      end
+      raise AzureApiError.new("Async operation timed out after #{MAX_POLL_SECONDS} seconds", 504)
+    end
+
+    private
+
+    def handle_async_operation_poll(poll_response, resource_url, method)
+      unless poll_response.success?
+        raise AzureApiError.new("Async poll failed: HTTP #{poll_response.status} #{poll_response.body}", poll_response.status)
+      end
+      poll_json = begin
+                    JSON.parse(poll_response.body)
+                  rescue JSON::ParserError, TypeError => e
+                    raise AzureApiError.new("Async poll returned non-JSON body: #{poll_response.body&.truncate(200)}", poll_response.status)
+                  end
+      status = poll_json['status']
+      raise AzureApiError.new("Async poll response missing 'status' field: #{poll_response.body&.truncate(200)}", poll_response.status) unless status
+      case status
+      when 'Succeeded'
+        return poll_response if method == :delete
+        result = @authenticated_get.call(resource_url)
+        unless result.success?
+          raise AzureApiError.new("Final resource fetch failed after async Succeeded: HTTP #{result.status} #{result.body&.truncate(200)}", result.status)
+        end
+        result
+      when 'Failed', 'Canceled'
+        raise AzureApiError.new("Async operation #{status}: #{poll_json.dig('error', 'message')}", 500)
+      end
+    end
+
+    def handle_location_poll(poll_response)
+      if poll_response.success? && !poll_response.accepted?
+        poll_response
+      elsif poll_response.accepted?
+        nil
+      else
+        raise AzureApiError.new("Location poll failed: HTTP #{poll_response.status} #{poll_response.body}", poll_response.status)
+      end
+    end
+  end
+end

--- a/app/lib/foreman_azure_rm/azure_async_poller.rb
+++ b/app/lib/foreman_azure_rm/azure_async_poller.rb
@@ -14,10 +14,10 @@ module ForemanAzureRm
       location_url = response.header('Location')
       return nil unless async_url || location_url
 
-      deadline = Time.now + MAX_POLL_SECONDS
+      deadline = Time.zone.now + MAX_POLL_SECONDS
       last_response = response
-      while Time.now < deadline
-        interval = (last_response.header('Retry-After')&.to_i || DEFAULT_POLL_INTERVAL)
+      while Time.zone.now < deadline
+        interval = last_response.header('Retry-After')&.to_i || DEFAULT_POLL_INTERVAL
         sleep interval
 
         poll_url = async_url || location_url
@@ -35,23 +35,19 @@ module ForemanAzureRm
     private
 
     def handle_async_operation_poll(poll_response, resource_url, method)
-      unless poll_response.success?
-        raise AzureApiError.new("Async poll failed: HTTP #{poll_response.status} #{poll_response.body}", poll_response.status)
-      end
+      raise AzureApiError.new("Async poll failed: HTTP #{poll_response.status} #{poll_response.body}", poll_response.status) unless poll_response.success?
       poll_json = begin
-                    JSON.parse(poll_response.body)
-                  rescue JSON::ParserError, TypeError => e
-                    raise AzureApiError.new("Async poll returned non-JSON body: #{poll_response.body&.truncate(200)}", poll_response.status)
-                  end
+        JSON.parse(poll_response.body)
+      rescue JSON::ParserError, TypeError
+        raise AzureApiError.new("Async poll returned non-JSON body: #{poll_response.body&.truncate(200)}", poll_response.status)
+      end
       status = poll_json['status']
       raise AzureApiError.new("Async poll response missing 'status' field: #{poll_response.body&.truncate(200)}", poll_response.status) unless status
       case status
       when 'Succeeded'
         return poll_response if method == :delete
         result = @authenticated_get.call(resource_url)
-        unless result.success?
-          raise AzureApiError.new("Final resource fetch failed after async Succeeded: HTTP #{result.status} #{result.body&.truncate(200)}", result.status)
-        end
+        raise AzureApiError.new("Final resource fetch failed after async Succeeded: HTTP #{result.status} #{result.body&.truncate(200)}", result.status) unless result.success?
         result
       when 'Failed', 'Canceled'
         raise AzureApiError.new("Async operation #{status}: #{poll_json.dig('error', 'message')}", 500)

--- a/app/lib/foreman_azure_rm/azure_http_transport.rb
+++ b/app/lib/foreman_azure_rm/azure_http_transport.rb
@@ -43,7 +43,7 @@ module ForemanAzureRm
       http.read_timeout = read_timeout
 
       klass = { get: Net::HTTP::Get, post: Net::HTTP::Post,
-                 put: Net::HTTP::Put, delete: Net::HTTP::Delete }.fetch(method)
+                put: Net::HTTP::Put, delete: Net::HTTP::Delete }.fetch(method)
       req = klass.new(uri)
       headers.each { |k, v| req[k] = v }
       req.body = body if body

--- a/app/lib/foreman_azure_rm/azure_http_transport.rb
+++ b/app/lib/foreman_azure_rm/azure_http_transport.rb
@@ -1,0 +1,63 @@
+require 'net/http'
+require 'uri'
+
+module ForemanAzureRm
+  class AzureHttpTransport
+    Response = Struct.new(:status, :headers, :body, keyword_init: true) do
+      def success?
+        (200..299).cover?(status)
+      end
+
+      def redirect?
+        (300..399).cover?(status)
+      end
+
+      def accepted?
+        status == 202
+      end
+
+      def created?
+        status == 201
+      end
+
+      def no_content?
+        status == 204
+      end
+
+      def header(name)
+        headers[name] || headers[name.downcase] || headers[name.split('-').map(&:capitalize).join('-')]
+      end
+    end
+
+    def initialize(proxy_uri: URI.parse(''), ssl_cert_store: nil)
+      @proxy_uri = proxy_uri
+      @ssl_cert_store = ssl_cert_store
+    end
+
+    def request(method:, url:, headers: {}, body: nil, open_timeout: 30, read_timeout: 300)
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port, @proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password)
+      http.use_ssl = true
+      http.cert_store = @ssl_cert_store if @ssl_cert_store
+      http.open_timeout = open_timeout
+      http.read_timeout = read_timeout
+
+      klass = { get: Net::HTTP::Get, post: Net::HTTP::Post,
+                 put: Net::HTTP::Put, delete: Net::HTTP::Delete }.fetch(method)
+      req = klass.new(uri)
+      headers.each { |k, v| req[k] = v }
+      req.body = body if body
+
+      raw = http.request(req)
+      to_response(raw)
+    end
+
+    private
+
+    def to_response(raw)
+      hdrs = {}
+      raw.each_header { |k, v| hdrs[k] = v }
+      Response.new(status: raw.code.to_i, headers: hdrs, body: raw.body)
+    end
+  end
+end

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -1,7 +1,5 @@
-require 'net/http'
 require 'json'
 require 'uri'
-require 'ostruct'
 
 module ForemanAzureRm
   class AzureRestClient
@@ -18,8 +16,6 @@ module ForemanAzureRm
         ad_login: 'https://login.chinacloudapi.cn',
         resource_manager: 'https://management.chinacloudapi.cn',
       },
-      # Deprecated: Azure Germany closed on Oct 29, 2021.
-      # Kept for backward compatibility; will be removed in a future release.
       'azuregermancloud' => {
         ad_login: 'https://login.microsoftonline.de',
         resource_manager: 'https://management.microsoftazure.de',
@@ -28,7 +24,7 @@ module ForemanAzureRm
 
     attr_reader :subscription_id
 
-    def initialize(tenant:, client_id:, client_secret:, subscription_id:, azure_environment: 'azure')
+    def initialize(tenant:, client_id:, client_secret:, subscription_id:, azure_environment: 'azure', proxy_url: nil, ssl_cert_store: nil)
       @tenant = tenant
       @client_id = client_id
       @client_secret = client_secret
@@ -39,6 +35,12 @@ module ForemanAzureRm
       @base_url = env[:resource_manager]
       @token = nil
       @token_expires_at = Time.at(0)
+      @transport = AzureHttpTransport.new(
+        proxy_uri: URI.parse(proxy_url || ENV['https_proxy'] || ENV['HTTPS_PROXY'] || ''),
+        ssl_cert_store: ssl_cert_store
+      )
+      @translator = AzureShapeTranslator.new
+      @poller = AzureAsyncPoller.new { |url| authenticated_get(url) }
     end
 
     def get(path, api_version:, params: {})
@@ -61,7 +63,7 @@ module ForemanAzureRm
       results = []
       loop do
         response = get(path, api_version: api_version, params: params)
-        items = response.respond_to?(:value) ? response.value : []
+        items = response.respond_to?(:value) ? (response.value || []) : []
         results.concat(items)
         next_link = response.respond_to?(:next_link) ? response.next_link : nil
         break unless next_link
@@ -74,170 +76,101 @@ module ForemanAzureRm
 
     private
 
-    # New Net::HTTP per request (no connection pooling). Acceptable for
-    # Foreman's Azure call volume; revisit with Net::HTTP::Persistent if
-    # latency becomes a concern.
     def request(method, path, api_version: nil, params: {}, body: nil)
       ensure_token
+      url = build_url(path, api_version, params)
+      headers = auth_headers
+      headers['Content-Type'] = 'application/json'
+      headers['Accept'] = 'application/json'
+      serialized = body ? @translator.serialize_request(body) : nil
 
-      uri = build_uri(path, api_version, params)
-      req = build_request(method, uri, body)
-      response = build_http(uri, read_timeout: 300).request(req)
-
-      handle_response(response)
+      response = @transport.request(method: method, url: url, headers: headers, body: serialized)
+      handle_response(response, method, url)
     end
 
-    def build_http(uri, read_timeout: 30)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.open_timeout = 30
-      http.read_timeout = read_timeout
-      http
+    def handle_response(response, method, resource_url)
+      if response.accepted? || response.created?
+        if response.header('Azure-AsyncOperation') || response.header('Location')
+          raw = @poller.poll(response, resource_url: resource_url, method: method)
+          return nil if method == :delete
+          return parse_body(raw) if raw
+        end
+        parse_body(response)
+      elsif response.redirect?
+        redirect_url = response.header('Location')
+        raise AzureApiError.new("Unexpected redirect to #{redirect_url}", response.status) unless redirect_url
+        request(:get, redirect_url)
+      elsif response.success?
+        if response.header('Azure-AsyncOperation')
+          raw = @poller.poll(response, resource_url: resource_url, method: method)
+          return nil if method == :delete
+          return parse_body(raw) if raw
+        end
+        parse_body(response)
+      else
+        raise_api_error(response)
+      end
     end
 
-    def build_uri(path, api_version, params)
+    def parse_body(response)
+      return nil if response.body.nil? || response.body.empty?
+      json = JSON.parse(response.body)
+      @translator.normalize_response(json)
+    end
+
+    def raise_api_error(response)
+      error = begin
+                JSON.parse(response.body)
+              rescue StandardError
+                { 'error' => { 'message' => response.body } }
+              end
+      err = error.dig('error', 'message') || error.dig('error', 'code') || "HTTP #{response.status}"
+      raise AzureApiError.new("Azure API error #{response.status}: #{err}", response.status)
+    end
+
+    def build_url(path, api_version, params)
       url = path.start_with?('http') ? path : "#{@base_url}#{path}"
       uri = URI.parse(url)
       query = URI.decode_www_form(uri.query || '')
       query << ['api-version', api_version] if api_version
       params.each { |k, v| query << [k.to_s, v.to_s] }
       uri.query = URI.encode_www_form(query)
-      uri
+      uri.to_s
     end
 
-    def build_request(method, uri, body)
-      klass = { get: Net::HTTP::Get, post: Net::HTTP::Post,
-                 put: Net::HTTP::Put, delete: Net::HTTP::Delete }.fetch(method)
-      req = klass.new(uri)
-      req['Authorization'] = "Bearer #{@token}"
-      req['Content-Type'] = 'application/json'
-      req['Accept'] = 'application/json'
-      req.body = serialize_body(body) if body
-      req
+    def auth_headers
+      { 'Authorization' => "Bearer #{@token}" }
     end
 
-    def serialize_body(body)
-      case body
-      when String then body
-      when OpenStruct then deep_camelize_keys(body.to_h).to_json
-      when Hash then deep_camelize_keys(body).to_json
-      else body.to_json
-      end
+    def authenticated_get(url)
+      ensure_token
+      @transport.request(method: :get, url: url, headers: auth_headers, read_timeout: 30)
     end
 
-    def handle_response(response)
-      case response
-      when Net::HTTPAccepted
-        poll_async_operation(response)
-      when Net::HTTPRedirection
-        redirect_url = response['Location']
-        raise AzureApiError.new("Unexpected redirect to #{redirect_url}", response.code.to_i) unless redirect_url
-        request(:get, redirect_url)
-      when Net::HTTPSuccess
-        return nil if response.body.nil? || response.body.empty?
-        json = JSON.parse(response.body)
-        wrap_response(json)
-      else
-        error = begin
-                  JSON.parse(response.body)
-                rescue StandardError
-                  { 'error' => { 'message' => response.body } }
-                end
-        err = error.dig('error', 'message') || error.dig('error', 'code') || response.message
-        raise AzureApiError.new("Azure API error #{response.code}: #{err}", response.code.to_i)
-      end
-    end
-
-    MAX_POLL_ATTEMPTS = 360
-    POLL_INTERVAL = 5
-
-    def poll_async_operation(response)
-      poll_url = response['Azure-AsyncOperation'] || response['Location']
-      resource_url = response.uri.to_s
-      return nil unless poll_url
-
-      MAX_POLL_ATTEMPTS.times do |attempt|
-        sleep POLL_INTERVAL
-        ensure_token
-        uri = URI.parse(poll_url)
-        req = Net::HTTP::Get.new(uri)
-        req['Authorization'] = "Bearer #{@token}"
-        poll_response = build_http(uri).request(req)
-        unless poll_response.is_a?(Net::HTTPSuccess)
-          raise AzureApiError.new("Async poll failed: HTTP #{poll_response.code} #{poll_response.body}", poll_response.code.to_i)
-        end
-        poll_json = JSON.parse(poll_response.body) rescue {}
-        status = poll_json['status']
-        case status
-        when 'Succeeded'
-          return request(:get, resource_url)
-        when 'Failed', 'Canceled'
-          raise AzureApiError.new("Async operation #{status}: #{poll_json.dig('error', 'message')}", 500)
-        end
-      end
-      raise AzureApiError.new("Async operation timed out after #{MAX_POLL_ATTEMPTS * POLL_INTERVAL} seconds", 504)
-    end
+    # --- Auth ---
 
     def ensure_token
       return if @token && Time.now < @token_expires_at - 60
 
-      uri = URI.parse("#{@ad_login_url}/#{@tenant}/oauth2/v2.0/token")
-      req = Net::HTTP::Post.new(uri)
-      req.set_form_data(
-        'grant_type' => 'client_credentials',
-        'client_id' => @client_id,
-        'client_secret' => @client_secret,
-        'scope' => "#{@base_url}/.default"
+      url = "#{@ad_login_url}/#{@tenant}/oauth2/v2.0/token"
+      response = @transport.request(
+        method: :post,
+        url: url,
+        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+        body: URI.encode_www_form(
+          'grant_type' => 'client_credentials',
+          'client_id' => @client_id,
+          'client_secret' => @client_secret,
+          'scope' => "#{@base_url}/.default"
+        ),
+        read_timeout: 30
       )
-      response = build_http(uri).request(req)
-      unless response.is_a?(Net::HTTPSuccess)
-        raise AzureApiError.new("Token acquisition failed: #{response.body}", response.code.to_i)
+      unless response.success?
+        raise AzureApiError.new("Token acquisition failed: #{response.body}", response.status)
       end
       token_data = JSON.parse(response.body)
       @token = token_data['access_token']
       @token_expires_at = Time.now + token_data['expires_in'].to_i
-    end
-
-    def wrap_response(data)
-      case data
-      when Hash then deep_to_ostruct(deep_underscore_keys(data))
-      when Array then data.map { |item| wrap_response(item) }
-      else data
-      end
-    end
-
-    def deep_to_ostruct(hash)
-      converted = hash.transform_values do |v|
-        case v
-        when Hash then deep_to_ostruct(v)
-        when Array then v.map { |item| item.is_a?(Hash) ? deep_to_ostruct(item) : item }
-        else v
-        end
-      end
-      OpenStruct.new(converted)
-    end
-
-    def deep_underscore_keys(hash)
-      hash.each_with_object({}) do |(k, v), result|
-        new_key = k.to_s.underscore
-        result[new_key] = case v
-                          when Hash then deep_underscore_keys(v)
-                          when Array then v.map { |item| item.is_a?(Hash) ? deep_underscore_keys(item) : item }
-                          else v
-                          end
-      end
-    end
-
-    def deep_camelize_keys(hash)
-      hash.each_with_object({}) do |(k, v), result|
-        new_key = k.to_s.camelize(:lower)
-        result[new_key] = case v
-                          when Hash then deep_camelize_keys(v)
-                          when Array then v.map { |item| item.is_a?(Hash) ? deep_camelize_keys(item) : item }
-                          when OpenStruct then deep_camelize_keys(v.to_h)
-                          else v
-                          end
-      end
     end
   end
 

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -119,12 +119,12 @@ module ForemanAzureRm
 
     def handle_response(response)
       case response
+      when Net::HTTPAccepted
+        poll_async_operation(response)
       when Net::HTTPSuccess
         return nil if response.body.nil? || response.body.empty?
         json = JSON.parse(response.body)
         wrap_response(json)
-      when Net::HTTPAccepted
-        poll_async_operation(response)
       else
         error = begin
                   JSON.parse(response.body)

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -20,7 +20,7 @@ module ForemanAzureRm
         ad_login: 'https://login.microsoftonline.de',
         resource_manager: 'https://management.microsoftazure.de',
       },
-    }
+    }.freeze
 
     attr_reader :subscription_id
 
@@ -34,7 +34,7 @@ module ForemanAzureRm
       @ad_login_url = env[:ad_login]
       @base_url = env[:resource_manager]
       @token = nil
-      @token_expires_at = Time.at(0)
+      @token_expires_at = Time.zone.at(0)
       @transport = AzureHttpTransport.new(
         proxy_uri: URI.parse(proxy_url || ENV['https_proxy'] || ENV['HTTPS_PROXY'] || ''),
         ssl_cert_store: ssl_cert_store
@@ -113,17 +113,17 @@ module ForemanAzureRm
     end
 
     def parse_body(response)
-      return nil if response.body.nil? || response.body.empty?
+      return nil if response.body.blank?
       json = JSON.parse(response.body)
       @translator.normalize_response(json)
     end
 
     def raise_api_error(response)
       error = begin
-                JSON.parse(response.body)
-              rescue StandardError
-                { 'error' => { 'message' => response.body } }
-              end
+        JSON.parse(response.body)
+      rescue StandardError
+        { 'error' => { 'message' => response.body } }
+      end
       err = error.dig('error', 'message') || error.dig('error', 'code') || "HTTP #{response.status}"
       raise AzureApiError.new("Azure API error #{response.status}: #{err}", response.status)
     end
@@ -150,7 +150,7 @@ module ForemanAzureRm
     # --- Auth ---
 
     def ensure_token
-      return if @token && Time.now < @token_expires_at - 60
+      return if @token && Time.zone.now < @token_expires_at - 60
 
       url = "#{@ad_login_url}/#{@tenant}/oauth2/v2.0/token"
       response = @transport.request(
@@ -165,12 +165,10 @@ module ForemanAzureRm
         ),
         read_timeout: 30
       )
-      unless response.success?
-        raise AzureApiError.new("Token acquisition failed: #{response.body}", response.status)
-      end
+      raise AzureApiError.new("Token acquisition failed: #{response.body}", response.status) unless response.success?
       token_data = JSON.parse(response.body)
       @token = token_data['access_token']
-      @token_expires_at = Time.now + token_data['expires_in'].to_i
+      @token_expires_at = Time.zone.now + token_data['expires_in'].to_i
     end
   end
 

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -18,6 +18,8 @@ module ForemanAzureRm
         ad_login: 'https://login.chinacloudapi.cn',
         resource_manager: 'https://management.chinacloudapi.cn',
       },
+      # Deprecated: Azure Germany closed on Oct 29, 2021.
+      # Kept for backward compatibility; will be removed in a future release.
       'azuregermancloud' => {
         ad_login: 'https://login.microsoftonline.de',
         resource_manager: 'https://management.microsoftazure.de',
@@ -72,6 +74,9 @@ module ForemanAzureRm
 
     private
 
+    # New Net::HTTP per request (no connection pooling). Acceptable for
+    # Foreman's Azure call volume; revisit with Net::HTTP::Persistent if
+    # latency becomes a concern.
     def request(method, path, api_version: nil, params: {}, body: nil)
       ensure_token
 

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -126,6 +126,10 @@ module ForemanAzureRm
       case response
       when Net::HTTPAccepted
         poll_async_operation(response)
+      when Net::HTTPRedirection
+        redirect_url = response['Location']
+        raise AzureApiError.new("Unexpected redirect to #{redirect_url}", response.code.to_i) unless redirect_url
+        request(:get, redirect_url)
       when Net::HTTPSuccess
         return nil if response.body.nil? || response.body.empty?
         json = JSON.parse(response.body)

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -138,6 +138,7 @@ module ForemanAzureRm
 
     def poll_async_operation(response)
       poll_url = response['Azure-AsyncOperation'] || response['Location']
+      resource_url = response.uri.to_s
       return nil unless poll_url
 
       loop do
@@ -151,7 +152,8 @@ module ForemanAzureRm
         poll_json = JSON.parse(poll_response.body)
         status = poll_json['status']
         case status
-        when 'Succeeded' then return wrap_response(poll_json)
+        when 'Succeeded'
+          return request(:get, resource_url)
         when 'Failed', 'Canceled'
           raise AzureApiError.new("Async operation #{status}: #{poll_json.dig('error', 'message')}", 500)
         end

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -1,0 +1,234 @@
+require 'net/http'
+require 'json'
+require 'uri'
+require 'ostruct'
+
+module ForemanAzureRm
+  class AzureRestClient
+    AZURE_ENVIRONMENTS = {
+      'azure' => {
+        ad_login: 'https://login.microsoftonline.com',
+        resource_manager: 'https://management.azure.com',
+      },
+      'azureusgovernment' => {
+        ad_login: 'https://login.microsoftonline.us',
+        resource_manager: 'https://management.usgovcloudapi.net',
+      },
+      'azurechina' => {
+        ad_login: 'https://login.chinacloudapi.cn',
+        resource_manager: 'https://management.chinacloudapi.cn',
+      },
+      'azuregermancloud' => {
+        ad_login: 'https://login.microsoftonline.de',
+        resource_manager: 'https://management.microsoftazure.de',
+      },
+    }
+
+    attr_reader :subscription_id
+
+    def initialize(tenant:, client_id:, client_secret:, subscription_id:, azure_environment: 'azure')
+      @tenant = tenant
+      @client_id = client_id
+      @client_secret = client_secret
+      @subscription_id = subscription_id
+      env = AZURE_ENVIRONMENTS[azure_environment.downcase]
+      raise ArgumentError, "Unknown Azure environment: #{azure_environment}" unless env
+      @ad_login_url = env[:ad_login]
+      @base_url = env[:resource_manager]
+      @token = nil
+      @token_expires_at = Time.at(0)
+    end
+
+    def get(path, api_version:, params: {})
+      request(:get, path, api_version: api_version, params: params)
+    end
+
+    def put(path, body, api_version:)
+      request(:put, path, api_version: api_version, body: body)
+    end
+
+    def post(path, body = nil, api_version:)
+      request(:post, path, api_version: api_version, body: body)
+    end
+
+    def delete(path, api_version:)
+      request(:delete, path, api_version: api_version)
+    end
+
+    def get_paged(path, api_version:, params: {})
+      results = []
+      loop do
+        response = get(path, api_version: api_version, params: params)
+        items = response.respond_to?(:value) ? response.value : []
+        results.concat(items)
+        next_link = response.respond_to?(:next_link) ? response.next_link : nil
+        break unless next_link
+        path = URI.parse(next_link).request_uri
+        params = {}
+        api_version = nil
+      end
+      results
+    end
+
+    private
+
+    def request(method, path, api_version: nil, params: {}, body: nil)
+      ensure_token
+
+      uri = build_uri(path, api_version, params)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = 60
+      http.read_timeout = 300
+
+      req = build_request(method, uri, body)
+      response = http.request(req)
+
+      handle_response(response)
+    end
+
+    def build_uri(path, api_version, params)
+      url = path.start_with?('http') ? path : "#{@base_url}#{path}"
+      uri = URI.parse(url)
+      query = URI.decode_www_form(uri.query || '')
+      query << ['api-version', api_version] if api_version
+      params.each { |k, v| query << [k.to_s, v.to_s] }
+      uri.query = URI.encode_www_form(query)
+      uri
+    end
+
+    def build_request(method, uri, body)
+      klass = { get: Net::HTTP::Get, post: Net::HTTP::Post,
+                 put: Net::HTTP::Put, delete: Net::HTTP::Delete }.fetch(method)
+      req = klass.new(uri)
+      req['Authorization'] = "Bearer #{@token}"
+      req['Content-Type'] = 'application/json'
+      req['Accept'] = 'application/json'
+      req.body = serialize_body(body) if body
+      req
+    end
+
+    def serialize_body(body)
+      case body
+      when String then body
+      when OpenStruct then deep_camelize_keys(body.to_h).to_json
+      when Hash then deep_camelize_keys(body).to_json
+      else body.to_json
+      end
+    end
+
+    def handle_response(response)
+      case response
+      when Net::HTTPSuccess
+        return nil if response.body.nil? || response.body.empty?
+        json = JSON.parse(response.body)
+        wrap_response(json)
+      when Net::HTTPAccepted
+        poll_async_operation(response)
+      else
+        error = begin
+                  JSON.parse(response.body)
+                rescue StandardError
+                  { 'error' => { 'message' => response.body } }
+                end
+        err = error.dig('error', 'message') || error.dig('error', 'code') || response.message
+        raise AzureApiError.new("Azure API error #{response.code}: #{err}", response.code.to_i)
+      end
+    end
+
+    def poll_async_operation(response)
+      poll_url = response['Azure-AsyncOperation'] || response['Location']
+      return nil unless poll_url
+
+      loop do
+        sleep 2
+        uri = URI.parse(poll_url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        req = Net::HTTP::Get.new(uri)
+        req['Authorization'] = "Bearer #{@token}"
+        poll_response = http.request(req)
+        poll_json = JSON.parse(poll_response.body)
+        status = poll_json['status']
+        case status
+        when 'Succeeded' then return wrap_response(poll_json)
+        when 'Failed', 'Canceled'
+          raise AzureApiError.new("Async operation #{status}: #{poll_json.dig('error', 'message')}", 500)
+        end
+      end
+    end
+
+    def ensure_token
+      return if @token && Time.now < @token_expires_at - 60
+
+      uri = URI.parse("#{@ad_login_url}/#{@tenant}/oauth2/v2.0/token")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      req = Net::HTTP::Post.new(uri)
+      req.set_form_data(
+        'grant_type' => 'client_credentials',
+        'client_id' => @client_id,
+        'client_secret' => @client_secret,
+        'scope' => "#{@base_url}/.default"
+      )
+      response = http.request(req)
+      unless response.is_a?(Net::HTTPSuccess)
+        raise AzureApiError.new("Token acquisition failed: #{response.body}", response.code.to_i)
+      end
+      token_data = JSON.parse(response.body)
+      @token = token_data['access_token']
+      @token_expires_at = Time.now + token_data['expires_in'].to_i
+    end
+
+    def wrap_response(data)
+      case data
+      when Hash then deep_to_ostruct(deep_underscore_keys(data))
+      when Array then data.map { |item| wrap_response(item) }
+      else data
+      end
+    end
+
+    def deep_to_ostruct(hash)
+      converted = hash.transform_values do |v|
+        case v
+        when Hash then deep_to_ostruct(v)
+        when Array then v.map { |item| item.is_a?(Hash) ? deep_to_ostruct(item) : item }
+        else v
+        end
+      end
+      OpenStruct.new(converted)
+    end
+
+    def deep_underscore_keys(hash)
+      hash.each_with_object({}) do |(k, v), result|
+        new_key = k.to_s.underscore
+        result[new_key] = case v
+                          when Hash then deep_underscore_keys(v)
+                          when Array then v.map { |item| item.is_a?(Hash) ? deep_underscore_keys(item) : item }
+                          else v
+                          end
+      end
+    end
+
+    def deep_camelize_keys(hash)
+      hash.each_with_object({}) do |(k, v), result|
+        new_key = k.to_s.camelize(:lower)
+        result[new_key] = case v
+                          when Hash then deep_camelize_keys(v)
+                          when Array then v.map { |item| item.is_a?(Hash) ? deep_camelize_keys(item) : item }
+                          when OpenStruct then deep_camelize_keys(v.to_h)
+                          else v
+                          end
+      end
+    end
+  end
+
+  class AzureApiError < StandardError
+    attr_reader :status_code
+
+    def initialize(message, status_code = nil)
+      super(message)
+      @status_code = status_code
+    end
+  end
+end

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -34,7 +34,7 @@ module ForemanAzureRm
       @ad_login_url = env[:ad_login]
       @base_url = env[:resource_manager]
       @token = nil
-      @token_expires_at = Time.zone.at(0)
+      @token_expires_at = 0
       @transport = AzureHttpTransport.new(
         proxy_uri: URI.parse(proxy_url || ENV['https_proxy'] || ENV['HTTPS_PROXY'] || ''),
         ssl_cert_store: ssl_cert_store
@@ -150,7 +150,7 @@ module ForemanAzureRm
     # --- Auth ---
 
     def ensure_token
-      return if @token && Time.zone.now < @token_expires_at - 60
+      return if @token && Process.clock_gettime(Process::CLOCK_MONOTONIC) < @token_expires_at - 60
 
       url = "#{@ad_login_url}/#{@tenant}/oauth2/v2.0/token"
       response = @transport.request(
@@ -168,7 +168,7 @@ module ForemanAzureRm
       raise AzureApiError.new("Token acquisition failed: #{response.body}", response.status) unless response.success?
       token_data = JSON.parse(response.body)
       @token = token_data['access_token']
-      @token_expires_at = Time.zone.now + token_data['expires_in'].to_i
+      @token_expires_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + token_data['expires_in'].to_i
     end
   end
 

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -160,6 +160,9 @@ module ForemanAzureRm
         req = Net::HTTP::Get.new(uri)
         req['Authorization'] = "Bearer #{@token}"
         poll_response = http.request(req)
+        unless poll_response.is_a?(Net::HTTPSuccess)
+          raise AzureApiError.new("Async poll failed: HTTP #{poll_response.code} #{poll_response.body}", poll_response.code.to_i)
+        end
         poll_json = JSON.parse(poll_response.body) rescue {}
         status = poll_json['status']
         case status

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -173,6 +173,8 @@ module ForemanAzureRm
       uri = URI.parse("#{@ad_login_url}/#{@tenant}/oauth2/v2.0/token")
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
+      http.open_timeout = 30
+      http.read_timeout = 30
       req = Net::HTTP::Post.new(uri)
       req.set_form_data(
         'grant_type' => 'client_credentials',

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -81,15 +81,18 @@ module ForemanAzureRm
       ensure_token
 
       uri = build_uri(path, api_version, params)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.open_timeout = 60
-      http.read_timeout = 300
-
       req = build_request(method, uri, body)
-      response = http.request(req)
+      response = build_http(uri, read_timeout: 300).request(req)
 
       handle_response(response)
+    end
+
+    def build_http(uri, read_timeout: 30)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = 30
+      http.read_timeout = read_timeout
+      http
     end
 
     def build_uri(path, api_version, params)
@@ -157,13 +160,9 @@ module ForemanAzureRm
         sleep POLL_INTERVAL
         ensure_token
         uri = URI.parse(poll_url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.open_timeout = 30
-        http.read_timeout = 30
         req = Net::HTTP::Get.new(uri)
         req['Authorization'] = "Bearer #{@token}"
-        poll_response = http.request(req)
+        poll_response = build_http(uri).request(req)
         unless poll_response.is_a?(Net::HTTPSuccess)
           raise AzureApiError.new("Async poll failed: HTTP #{poll_response.code} #{poll_response.body}", poll_response.code.to_i)
         end
@@ -183,10 +182,6 @@ module ForemanAzureRm
       return if @token && Time.now < @token_expires_at - 60
 
       uri = URI.parse("#{@ad_login_url}/#{@tenant}/oauth2/v2.0/token")
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.open_timeout = 30
-      http.read_timeout = 30
       req = Net::HTTP::Post.new(uri)
       req.set_form_data(
         'grant_type' => 'client_credentials',
@@ -194,7 +189,7 @@ module ForemanAzureRm
         'client_secret' => @client_secret,
         'scope' => "#{@base_url}/.default"
       )
-      response = http.request(req)
+      response = build_http(uri).request(req)
       unless response.is_a?(Net::HTTPSuccess)
         raise AzureApiError.new("Token acquisition failed: #{response.body}", response.code.to_i)
       end

--- a/app/lib/foreman_azure_rm/azure_rest_client.rb
+++ b/app/lib/foreman_azure_rm/azure_rest_client.rb
@@ -136,20 +136,26 @@ module ForemanAzureRm
       end
     end
 
+    MAX_POLL_ATTEMPTS = 360
+    POLL_INTERVAL = 5
+
     def poll_async_operation(response)
       poll_url = response['Azure-AsyncOperation'] || response['Location']
       resource_url = response.uri.to_s
       return nil unless poll_url
 
-      loop do
-        sleep 2
+      MAX_POLL_ATTEMPTS.times do |attempt|
+        sleep POLL_INTERVAL
+        ensure_token
         uri = URI.parse(poll_url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
+        http.open_timeout = 30
+        http.read_timeout = 30
         req = Net::HTTP::Get.new(uri)
         req['Authorization'] = "Bearer #{@token}"
         poll_response = http.request(req)
-        poll_json = JSON.parse(poll_response.body)
+        poll_json = JSON.parse(poll_response.body) rescue {}
         status = poll_json['status']
         case status
         when 'Succeeded'
@@ -158,6 +164,7 @@ module ForemanAzureRm
           raise AzureApiError.new("Async operation #{status}: #{poll_json.dig('error', 'message')}", 500)
         end
       end
+      raise AzureApiError.new("Async operation timed out after #{MAX_POLL_ATTEMPTS * POLL_INTERVAL} seconds", 504)
     end
 
     def ensure_token

--- a/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -166,8 +166,11 @@ module ForemanAzureRm
       compute_post(rg_name, "virtualMachines/#{vm_name}/deallocate")
     end
 
+    MAX_GALLERY_CACHE_SIZE = 100
+
     def self.gallery_caching(rg_name)
       @gallery_caching ||= {}
+      @gallery_caching.shift if @gallery_caching.size > MAX_GALLERY_CACHE_SIZE
       @gallery_caching[rg_name] ||= {}
     end
 

--- a/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -7,7 +7,7 @@ module ForemanAzureRm
       storage: '2023-01-01',
       resources: '2021-04-01',
       subscriptions: '2022-12-01',
-    }
+    }.freeze
 
     def initialize(tenant, app_ident, secret_key, sub_id, azure_environment, proxy_url: nil, ssl_cert_store: nil)
       @sub_id = sub_id

--- a/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -9,14 +9,16 @@ module ForemanAzureRm
       subscriptions: '2022-12-01',
     }
 
-    def initialize(tenant, app_ident, secret_key, sub_id, azure_environment)
+    def initialize(tenant, app_ident, secret_key, sub_id, azure_environment, proxy_url: nil, ssl_cert_store: nil)
       @sub_id = sub_id
       @client = AzureRestClient.new(
         tenant: tenant,
         client_id: app_ident,
         client_secret: secret_key,
         subscription_id: sub_id,
-        azure_environment: azure_environment
+        azure_environment: azure_environment,
+        proxy_url: proxy_url,
+        ssl_cert_store: ssl_cert_store
       )
     end
 
@@ -150,7 +152,7 @@ module ForemanAzureRm
     end
 
     def get_status(virtual_machine)
-      statuses = virtual_machine.properties&.instance_view&.statuses || []
+      statuses = virtual_machine.instance_view&.statuses || []
       statuses.each do |status|
         return status.code.split('/')[1] if status.code.include?('PowerState')
       end
@@ -168,21 +170,41 @@ module ForemanAzureRm
 
     MAX_GALLERY_CACHE_SIZE = 100
 
-    def self.gallery_caching(rg_name)
-      @gallery_caching ||= {}
-      @gallery_caching.shift if @gallery_caching.size > MAX_GALLERY_CACHE_SIZE
-      @gallery_caching[rg_name] ||= {}
+    def self.gallery_cache(subscription_id)
+      @gallery_cache ||= {}
+      @gallery_cache[subscription_id] ||= {}
+      @gallery_cache[subscription_id].shift if @gallery_cache[subscription_id].size > MAX_GALLERY_CACHE_SIZE
+      @gallery_cache[subscription_id]
     end
 
-    def actual_gallery_image_id(rg_name, image_id)
-      gallery_names = list_galleries.map(&:name)
-      return unless (gallery = gallery_names.first)
-      gallery_image = list_gallery_images(rg_name, gallery).detect { |image| image.name == image_id }
-      gallery_image&.id
+    def actual_gallery_image_id(_rg_name, image_id)
+      parts = image_id.split('/')
+      case parts.length
+      when 3
+        rg, gallery_name, image_name = parts
+        gallery_image = list_gallery_images(rg, gallery_name).detect { |img| img.name == image_name }
+        gallery_image&.id
+      when 2
+        gallery_name, image_name = parts
+        matches = list_galleries.select { |g| g.name == gallery_name }.filter_map do |gallery|
+          gallery_rg = gallery.resource_group || gallery.id&.split('/')&.dig(4)
+          list_gallery_images(gallery_rg, gallery_name).detect { |img| img.name == image_name }
+        end
+        raise ArgumentError, "Gallery image '#{image_id}' is ambiguous across resource groups; use gallery://<resource_group>/#{image_id}" if matches.length > 1
+        matches.first&.id
+      when 1
+        image_name = parts[0]
+        matches = list_galleries.filter_map do |gallery|
+          gallery_rg = gallery.resource_group || gallery.id&.split('/')&.dig(4)
+          list_gallery_images(gallery_rg, gallery.name).detect { |img| img.name == image_name }
+        end
+        raise ArgumentError, "Gallery image '#{image_name}' is ambiguous; use gallery://<resource_group>/<gallery>/#{image_name}" if matches.length > 1
+        matches.first&.id
+      end
     end
 
-    def fetch_gallery_image_id(rg_name, image_id)
-      AzureSdkAdapter.gallery_caching(rg_name)[image_id] ||= actual_gallery_image_id(rg_name, image_id)
+    def fetch_gallery_image_id(_rg_name, image_id)
+      AzureSdkAdapter.gallery_cache(@sub_id)[image_id] ||= actual_gallery_image_id(nil, image_id)
     end
 
     private

--- a/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -1,234 +1,169 @@
 module ForemanAzureRm
   class AzureSdkAdapter
+    API_VERSIONS = {
+      compute: '2023-03-01',
+      disks: '2023-02-02',
+      network: '2023-04-01',
+      storage: '2023-01-01',
+      resources: '2021-04-01',
+      subscriptions: '2022-12-01',
+    }
+
     def initialize(tenant, app_ident, secret_key, sub_id, azure_environment)
-      @tenant               = tenant
-      @app_ident            = app_ident
-      @secret_key           = secret_key
-      @sub_id               = sub_id
-      @azure_environment    = azure_environment
-      @ad_settings          = ad_environment_settings(azure_environment)
-      @environment_settings = environment_settings(azure_environment)
-    end
-
-    def resource_client
-      # resource_manager_endpoint_url
-      @resource_client ||= Resources::Client.new(azure_credentials(@environment_settings.resource_manager_endpoint_url))
-    end
-
-    def compute_client
-      @compute_client ||= Compute::Client.new(azure_credentials(@environment_settings.resource_manager_endpoint_url))
-    end
-
-    def network_client
-      @network_client ||= Network::Client.new(azure_credentials(@environment_settings.resource_manager_endpoint_url))
-    end
-
-    def storage_client
-      @storage_client ||= Storage::Client.new(azure_credentials(@environment_settings.resource_manager_endpoint_url))
-    end
-
-    def subscription_client
-      @subscription_client ||= Subscriptions::Client.new(azure_credentials(@environment_settings.resource_manager_endpoint_url))
-    end
-
-    def azure_credentials(base_url)
-      provider = MsRestAzure::ApplicationTokenProvider.new(
-        @tenant,
-        @app_ident,
-        @secret_key,
-        @ad_settings
+      @sub_id = sub_id
+      @client = AzureRestClient.new(
+        tenant: tenant,
+        client_id: app_ident,
+        client_secret: secret_key,
+        subscription_id: sub_id,
+        azure_environment: azure_environment
       )
-
-      credentials = MsRest::TokenCredentials.new(provider)
-
-      {
-        credentials: credentials,
-        tenant_id: @tenant,
-        client_id: @app_ident,
-        client_secret: @secret_key,
-        subscription_id: @sub_id,
-        base_url: base_url,
-      }
-    end
-
-    # https://github.com/Azure/azure-sdk-for-ruby/issues/850
-    # Retrieves a [MsRestAzure::ActiveDirectoryServiceSettings] object representing the settings for the given cloud.
-    # @param azure_environment [String] The Azure environment to retrieve settings for.
-    #
-    # @return [MsRestAzure::ActiveDirectoryServiceSettings] Settings to be used for subsequent requests
-    #
-    def ad_environment_settings(azure_environment)
-      case azure_environment.downcase
-      when 'azureusgovernment'
-        MsRestAzure::ActiveDirectoryServiceSettings.get_azure_us_government_settings
-      when 'azurechina'
-        MsRestAzure::ActiveDirectoryServiceSettings.get_azure_china_settings
-      when 'azuregermancloud'
-        MsRestAzure::ActiveDirectoryServiceSettings.get_azure_german_settings
-      when 'azure'
-        MsRestAzure::ActiveDirectoryServiceSettings.get_azure_settings
-      end
-    end
-
-    def environment_settings(azure_environment)
-      case azure_environment.downcase
-      when 'azureusgovernment'
-        MsRestAzure::AzureEnvironments::AzureUSGovernment
-      when 'azurechina'
-        MsRestAzure::AzureEnvironments::AzureChinaCloud
-      when 'azuregermancloud'
-        MsRestAzure::AzureEnvironments::AzureGermanCloud
-      when 'azure'
-        MsRestAzure::AzureEnvironments::AzureCloud
-      end
     end
 
     def list_regions(subscription_id)
-      subscription_client.subscriptions.list_locations(subscription_id)
+      @client.get("/subscriptions/#{subscription_id}/locations", api_version: API_VERSIONS[:subscriptions])
     end
 
     def list_resources(filter)
-      resource_client.resources.list(filter)
+      @client.get_paged(sub_path('resources'), api_version: API_VERSIONS[:resources], params: { '$filter' => filter })
     end
 
     def rgs
-      rgs = resource_client.resource_groups.list
-      rgs.map(&:name)
+      @client.get_paged(sub_path('resourcegroups'), api_version: API_VERSIONS[:resources]).map(&:name)
     end
 
     def vnets
-      network_client.virtual_networks.list_all
+      @client.get_paged(provider_path('Microsoft.Network', 'virtualNetworks'), api_version: API_VERSIONS[:network])
     end
 
     def subnets(rg_name, vnet_name)
-      network_client.subnets.list(rg_name, vnet_name)
+      @client.get_paged(rg_provider_path(rg_name, 'Microsoft.Network', "virtualNetworks/#{vnet_name}/subnets"), api_version: API_VERSIONS[:network])
     end
 
     def public_ip(rg_name, pip_name)
-      network_client.public_ipaddresses.get(rg_name, pip_name)
+      network_get(rg_name, "publicIPAddresses/#{pip_name}")
     end
 
     def vm_nic(rg_name, nic_name)
-      network_client.network_interfaces.get(rg_name, nic_name)
+      network_get(rg_name, "networkInterfaces/#{nic_name}")
     end
 
     def vm_disk(rg_name, disk_name)
-      compute_client.disks.get(rg_name, disk_name)
+      @client.get(rg_provider_path(rg_name, 'Microsoft.Compute', "disks/#{disk_name}"), api_version: API_VERSIONS[:disks])
     end
 
     def get_vm_extension(rg_name, vm_name, vm_extension_name)
-      compute_client.virtual_machine_extensions.get(rg_name, vm_name, vm_extension_name)
+      compute_get(rg_name, "virtualMachines/#{vm_name}/extensions/#{vm_extension_name}")
     end
 
     def list_vm_sizes(region)
       return [] if region.blank?
-
       stripped_region = region.gsub(/\s+/, '').downcase
-      compute_client.virtual_machine_sizes.list(stripped_region).value
+      response = @client.get(provider_path('Microsoft.Compute', "locations/#{stripped_region}/vmSizes"), api_version: API_VERSIONS[:compute])
+      response.value || []
     end
 
     def list_vms(region)
-      # List all VMs in a resource group
-      compute_client.virtual_machines.list_by_location(region)
+      @client.get_paged(provider_path('Microsoft.Compute', 'virtualMachines'), api_version: API_VERSIONS[:compute], params: { '$filter' => "location eq '#{region}'" })
     end
 
     def get_vm(rg_name, vm_name)
-      compute_client.virtual_machines.get(rg_name, vm_name)
+      compute_get(rg_name, "virtualMachines/#{vm_name}")
     end
 
     def get_marketplace_image(location, publisher_name, offer, skus, version)
-      compute_client.virtual_machine_images.get(location, publisher_name, offer, skus, version)
+      @client.get(provider_path('Microsoft.Compute',
+        "locations/#{location}/publishers/#{publisher_name}/artifacttypes/vmimage/offers/#{offer}/skus/#{skus}/versions/#{version}"),
+        api_version: API_VERSIONS[:compute])
     end
 
     def list_versions(location, publisher_name, offer, skus)
-      compute_client.virtual_machine_images.list(location, publisher_name, offer, skus)
+      @client.get_paged(provider_path('Microsoft.Compute',
+        "locations/#{location}/publishers/#{publisher_name}/artifacttypes/vmimage/offers/#{offer}/skus/#{skus}/versions"),
+        api_version: API_VERSIONS[:compute])
     end
 
     def list_custom_images
-      compute_client.images.list
+      @client.get_paged(provider_path('Microsoft.Compute', 'images'), api_version: API_VERSIONS[:compute])
     end
 
     def get_custom_image(rg_name, image_name)
-      compute_client.images.get(rg_name, image_name)
+      compute_get(rg_name, "images/#{image_name}")
     end
 
     def list_galleries
-      compute_client.galleries.list
+      @client.get_paged(provider_path('Microsoft.Compute', 'galleries'), api_version: API_VERSIONS[:compute])
     end
 
     def list_gallery_images(rg_name, gallery_name)
-      compute_client.gallery_images.list_by_gallery(rg_name, gallery_name)
+      @client.get_paged(rg_provider_path(rg_name, 'Microsoft.Compute', "galleries/#{gallery_name}/images"), api_version: API_VERSIONS[:compute])
     end
 
     def get_gallery_image(rg_name, gallery_name, gallery_image_name)
-      compute_client.gallery_images.get(rg_name, gallery_name, gallery_image_name)
+      compute_get(rg_name, "galleries/#{gallery_name}/images/#{gallery_image_name}")
     end
 
     def list_gallery_image_versions(rg_name, gallery_name, gallery_image_name)
-      compute_client.gallery_image_versions.list_by_gallery_image(rg_name, gallery_name, gallery_image_name)
+      @client.get_paged(rg_provider_path(rg_name, 'Microsoft.Compute', "galleries/#{gallery_name}/images/#{gallery_image_name}/versions"), api_version: API_VERSIONS[:compute])
     end
 
-    def get_storage_accts # rubocop:disable Naming/AccessorMethodName
-      result = storage_client.storage_accounts.list
-      result.value
+    def get_storage_accts
+      response = @client.get(provider_path('Microsoft.Storage', 'storageAccounts'), api_version: API_VERSIONS[:storage])
+      response.value || []
     end
 
     def create_or_update_vm(rg_name, vm_name, parameters)
-      compute_client.virtual_machines.create_or_update(rg_name, vm_name, parameters)
+      compute_put(rg_name, "virtualMachines/#{vm_name}", parameters)
     end
 
     def create_or_update_vm_extensions(rg_name, vm_name, vm_extension_name, extension_params)
-      compute_client.virtual_machine_extensions.create_or_update(rg_name,
-        vm_name,
-        vm_extension_name,
-        extension_params)
+      compute_put(rg_name, "virtualMachines/#{vm_name}/extensions/#{vm_extension_name}", extension_params)
     end
 
     def create_or_update_pip(rg_name, pip_name, parameters)
-      network_client.public_ipaddresses.create_or_update(rg_name, pip_name, parameters)
+      network_put(rg_name, "publicIPAddresses/#{pip_name}", parameters)
     end
 
     def create_or_update_nic(rg_name, nic_name, parameters)
-      network_client.network_interfaces.create_or_update(rg_name, nic_name, parameters)
+      network_put(rg_name, "networkInterfaces/#{nic_name}", parameters)
     end
 
     def delete_pip(rg_name, pip_name)
-      network_client.public_ipaddresses.delete(rg_name, pip_name)
+      network_delete(rg_name, "publicIPAddresses/#{pip_name}")
     end
 
     def delete_nic(rg_name, nic_name)
-      network_client.network_interfaces.delete(rg_name, nic_name)
+      network_delete(rg_name, "networkInterfaces/#{nic_name}")
     end
 
     def delete_vm(rg_name, vm_name)
-      compute_client.virtual_machines.delete(rg_name, vm_name)
+      compute_delete(rg_name, "virtualMachines/#{vm_name}")
     end
 
     def delete_disk(rg_name, disk_name)
-      compute_client.disks.delete(rg_name, disk_name)
+      @client.delete(rg_provider_path(rg_name, 'Microsoft.Compute', "disks/#{disk_name}"), api_version: API_VERSIONS[:disks])
     end
 
     def check_vm_status(rg_name, vm_name)
-      virtual_machine = compute_client.virtual_machines.get(rg_name, vm_name, expand: 'instanceView')
-      get_status(virtual_machine)
+      vm = @client.get(rg_provider_path(rg_name, 'Microsoft.Compute', "virtualMachines/#{vm_name}"), api_version: API_VERSIONS[:compute], params: { '$expand' => 'instanceView' })
+      get_status(vm)
     end
 
     def get_status(virtual_machine)
-      vm_statuses = virtual_machine.instance_view.statuses
-      vm_status = nil
-      vm_statuses.each do |status|
-        vm_status = status.code.split('/')[1] if status.code.include? 'PowerState'
+      statuses = virtual_machine.properties&.instance_view&.statuses || []
+      statuses.each do |status|
+        return status.code.split('/')[1] if status.code.include?('PowerState')
       end
-      vm_status
+      nil
     end
 
     def start_vm(rg_name, vm_name)
-      compute_client.virtual_machines.start(rg_name, vm_name)
+      compute_post(rg_name, "virtualMachines/#{vm_name}/start")
     end
 
     def stop_vm(rg_name, vm_name)
-      compute_client.virtual_machines.power_off(rg_name, vm_name)
-      compute_client.virtual_machines.deallocate(rg_name, vm_name)
+      compute_post(rg_name, "virtualMachines/#{vm_name}/powerOff")
+      compute_post(rg_name, "virtualMachines/#{vm_name}/deallocate")
     end
 
     def self.gallery_caching(rg_name)
@@ -239,13 +174,54 @@ module ForemanAzureRm
     def actual_gallery_image_id(rg_name, image_id)
       gallery_names = list_galleries.map(&:name)
       return unless (gallery = gallery_names.first)
-
       gallery_image = list_gallery_images(rg_name, gallery).detect { |image| image.name == image_id }
       gallery_image&.id
     end
 
     def fetch_gallery_image_id(rg_name, image_id)
       AzureSdkAdapter.gallery_caching(rg_name)[image_id] ||= actual_gallery_image_id(rg_name, image_id)
+    end
+
+    private
+
+    def sub_path(resource)
+      "/subscriptions/#{@sub_id}/#{resource}"
+    end
+
+    def provider_path(provider, resource)
+      "/subscriptions/#{@sub_id}/providers/#{provider}/#{resource}"
+    end
+
+    def rg_provider_path(rg_name, provider, resource)
+      "/subscriptions/#{@sub_id}/resourceGroups/#{rg_name}/providers/#{provider}/#{resource}"
+    end
+
+    def compute_get(rg_name, resource)
+      @client.get(rg_provider_path(rg_name, 'Microsoft.Compute', resource), api_version: API_VERSIONS[:compute])
+    end
+
+    def compute_put(rg_name, resource, body)
+      @client.put(rg_provider_path(rg_name, 'Microsoft.Compute', resource), body, api_version: API_VERSIONS[:compute])
+    end
+
+    def compute_post(rg_name, resource)
+      @client.post(rg_provider_path(rg_name, 'Microsoft.Compute', resource), nil, api_version: API_VERSIONS[:compute])
+    end
+
+    def compute_delete(rg_name, resource)
+      @client.delete(rg_provider_path(rg_name, 'Microsoft.Compute', resource), api_version: API_VERSIONS[:compute])
+    end
+
+    def network_get(rg_name, resource)
+      @client.get(rg_provider_path(rg_name, 'Microsoft.Network', resource), api_version: API_VERSIONS[:network])
+    end
+
+    def network_put(rg_name, resource, body)
+      @client.put(rg_provider_path(rg_name, 'Microsoft.Network', resource), body, api_version: API_VERSIONS[:network])
+    end
+
+    def network_delete(rg_name, resource)
+      @client.delete(rg_provider_path(rg_name, 'Microsoft.Network', resource), api_version: API_VERSIONS[:network])
     end
   end
 end

--- a/app/lib/foreman_azure_rm/azure_shape_translator.rb
+++ b/app/lib/foreman_azure_rm/azure_shape_translator.rb
@@ -1,0 +1,144 @@
+require 'ostruct'
+require 'set'
+
+module ForemanAzureRm
+  class AzureShapeTranslator
+    # --- Inbound: ARM REST JSON → SDK-compatible OpenStruct ---
+
+    INBOUND_KEY_FIXES = {
+      'disk_size_g_b' => 'disk_size_gb',
+      'public_i_p_address' => 'public_ipaddress',
+      'public_i_p_allocation_method' => 'public_ipallocation_method',
+      'private_i_p_address' => 'private_ipaddress',
+      'private_i_p_allocation_method' => 'private_ipallocation_method',
+    }.freeze
+
+    def normalize_response(data)
+      case data
+      when Hash then deep_to_ostruct(normalize_inbound(data))
+      when Array then data.map { |item| normalize_response(item) }
+      else data
+      end
+    end
+
+    # --- Outbound: SDK-shaped OpenStruct → ARM REST JSON string ---
+
+    OUTBOUND_KEY_MAP = {
+      'public_ipallocation_method' => 'publicIPAllocationMethod',
+      'private_ipallocation_method' => 'privateIPAllocationMethod',
+      'public_ipaddress' => 'publicIPAddress',
+      'private_ipaddress' => 'privateIPAddress',
+      'disk_size_gb' => 'diskSizeGB',
+      'virtual_machine_extension_type' => 'type',
+      'ip_configurations' => 'ipConfigurations',
+      'ip_address' => 'ipAddress',
+    }.freeze
+
+    ARM_TOP_LEVEL_FIELDS = %w[location tags name id plan sku zones identity kind].freeze
+
+    SUB_RESOURCE_ARRAYS = Set.new(%w[ipConfigurations networkInterfaces]).freeze
+
+    def serialize_request(body)
+      case body
+      when String then body
+      when OpenStruct then arm_serialize(body.to_h).to_json
+      when Hash then arm_serialize(body).to_json
+      else body.to_json
+      end
+    end
+
+    private
+
+    # -- Inbound internals --
+
+    def normalize_inbound(hash)
+      h = underscore_keys(hash)
+      flatten_and_enrich(h)
+    end
+
+    def underscore_keys(hash)
+      hash.each_with_object({}) do |(k, v), result|
+        new_key = k.to_s.underscore
+        new_key = INBOUND_KEY_FIXES[new_key] || new_key
+        result[new_key] = case v
+                          when Hash then underscore_keys(v)
+                          when Array then v.map { |item| item.is_a?(Hash) ? underscore_keys(item) : item }
+                          else v
+                          end
+      end
+    end
+
+    def flatten_and_enrich(hash)
+      if hash.key?('properties') && hash['properties'].is_a?(Hash)
+        hash = hash.merge(hash.delete('properties'))
+      end
+      id = hash['id']
+      if id.is_a?(String) && id.include?('/resourceGroups/')
+        parts = id.split('/')
+        rg_index = parts.index { |p| p.casecmp('resourceGroups').zero? }
+        hash['resource_group'] = parts[rg_index + 1] if rg_index
+      end
+      hash.transform_values do |v|
+        case v
+        when Hash then flatten_and_enrich(v)
+        when Array then v.map { |item| item.is_a?(Hash) ? flatten_and_enrich(item) : item }
+        else v
+        end
+      end
+    end
+
+    def deep_to_ostruct(hash)
+      converted = hash.transform_values do |v|
+        case v
+        when Hash then deep_to_ostruct(v)
+        when Array then v.map { |item| item.is_a?(Hash) ? deep_to_ostruct(item) : item }
+        else v
+        end
+      end
+      OpenStruct.new(converted)
+    end
+
+    # -- Outbound internals --
+
+    def arm_serialize(hash)
+      camelized = arm_camelize(hash)
+      wrap_in_properties(camelized)
+    end
+
+    def arm_camelize(hash)
+      hash.each_with_object({}) do |(k, v), result|
+        key_s = k.to_s
+        new_key = OUTBOUND_KEY_MAP[key_s] || key_s.camelize(:lower)
+        result[new_key] = if SUB_RESOURCE_ARRAYS.include?(new_key) && v.is_a?(Array)
+                            v.map { |item| wrap_in_properties(arm_camelize_value(item)) }
+                          else
+                            arm_camelize_value(v)
+                          end
+      end
+    end
+
+    def arm_camelize_value(v)
+      case v
+      when Hash then arm_camelize(v)
+      when OpenStruct then arm_camelize(v.to_h)
+      when Array then v.map { |item| arm_camelize_value(item) }
+      else v
+      end
+    end
+
+    def wrap_in_properties(hash)
+      return hash unless hash.is_a?(Hash)
+      top = {}
+      props = {}
+      hash.each do |k, v|
+        if ARM_TOP_LEVEL_FIELDS.include?(k)
+          top[k] = v
+        else
+          props[k] = v
+        end
+      end
+      top['properties'] = props unless props.empty?
+      top
+    end
+  end
+end

--- a/app/lib/foreman_azure_rm/azure_shape_translator.rb
+++ b/app/lib/foreman_azure_rm/azure_shape_translator.rb
@@ -73,7 +73,7 @@ module ForemanAzureRm
       id = hash['id']
       if id.is_a?(String) && id.include?('/resourceGroups/')
         parts = id.split('/')
-        rg_index = parts.index { |p| p.casecmp('resourceGroups').zero? }
+        rg_index = parts.index { |p| p.casecmp?('resourceGroups') }
         hash['resource_group'] = parts[rg_index + 1] if rg_index
       end
       hash.transform_values do |v|

--- a/app/lib/foreman_azure_rm/azure_shape_translator.rb
+++ b/app/lib/foreman_azure_rm/azure_shape_translator.rb
@@ -10,7 +10,7 @@ module ForemanAzureRm
       'public_i_p_address' => 'public_ipaddress',
       'public_i_p_allocation_method' => 'public_ipallocation_method',
       'private_i_p_address' => 'private_ipaddress',
-      'private_i_p_allocation_method' => 'private_ipallocation_method',
+      'private_i_p_allocation_method' => 'private_ipallocation_method'
     }.freeze
 
     def normalize_response(data)
@@ -31,7 +31,7 @@ module ForemanAzureRm
       'disk_size_gb' => 'diskSizeGB',
       'virtual_machine_extension_type' => 'type',
       'ip_configurations' => 'ipConfigurations',
-      'ip_address' => 'ipAddress',
+      'ip_address' => 'ipAddress'
     }.freeze
 
     ARM_TOP_LEVEL_FIELDS = %w[location tags name id plan sku zones identity kind].freeze

--- a/app/lib/foreman_azure_rm/azure_shape_translator.rb
+++ b/app/lib/foreman_azure_rm/azure_shape_translator.rb
@@ -10,7 +10,7 @@ module ForemanAzureRm
       'public_i_p_address' => 'public_ipaddress',
       'public_i_p_allocation_method' => 'public_ipallocation_method',
       'private_i_p_address' => 'private_ipaddress',
-      'private_i_p_allocation_method' => 'private_ipallocation_method'
+      'private_i_p_allocation_method' => 'private_ipallocation_method',
     }.freeze
 
     def normalize_response(data)
@@ -31,7 +31,7 @@ module ForemanAzureRm
       'disk_size_gb' => 'diskSizeGB',
       'virtual_machine_extension_type' => 'type',
       'ip_configurations' => 'ipConfigurations',
-      'ip_address' => 'ipAddress'
+      'ip_address' => 'ipAddress',
     }.freeze
 
     ARM_TOP_LEVEL_FIELDS = %w[location tags name id plan sku zones identity kind].freeze
@@ -69,9 +69,7 @@ module ForemanAzureRm
     end
 
     def flatten_and_enrich(hash)
-      if hash.key?('properties') && hash['properties'].is_a?(Hash)
-        hash = hash.merge(hash.delete('properties'))
-      end
+      hash = hash.merge(hash.delete('properties')) if hash.key?('properties') && hash['properties'].is_a?(Hash)
       id = hash['id']
       if id.is_a?(String) && id.include?('/resourceGroups/')
         parts = id.split('/')

--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -185,9 +185,7 @@ module ForemanAzureRm
             end
           end
           unless vm_hash[:availability_set_id].nil?
-            sub_resource = MsRestAzure::SubResource.new
-            sub_resource.id = vm_hash[:availability_set_id]
-            vm.availability_set = sub_resource
+            vm.availability_set = OpenStruct.new(id: vm_hash[:availability_set_id])
           end
 
           vm.os_profile = ComputeModels::OSProfile.new.tap do |os_profile|

--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -44,7 +44,7 @@ module ForemanAzureRm
         unless data_disks.nil?
           disks = []
           disk_count = 0
-          data_disks.each do |disk_num, attrs|
+          data_disks.each_value do |attrs|
             managed_data_disk = OpenStruct.new
             disk = OpenStruct.new
             disk.name = "#{vm_name}-data-disk#{disk_count}"
@@ -186,9 +186,7 @@ module ForemanAzureRm
               vm.tags[kv[0].strip] = kv[1].strip
             end
           end
-          unless vm_hash[:availability_set_id].nil?
-            vm.availability_set = OpenStruct.new(id: vm_hash[:availability_set_id])
-          end
+          vm.availability_set = OpenStruct.new(id: vm_hash[:availability_set_id]) unless vm_hash[:availability_set_id].nil?
 
           vm.os_profile = OpenStruct.new.tap do |os_profile|
             os_profile.computer_name  = vm_hash[:name]

--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -122,6 +122,7 @@ module ForemanAzureRm
 
       def create_nics(region, args = {})
         nics               = []
+        pips               = []
         args[:interfaces_attributes].each do |nic, attrs|
           private_ip = ActiveRecord::Type::Boolean.new.deserialize(attrs[:private_ip])
           priv_ip_alloc       = if private_ip
@@ -148,6 +149,7 @@ module ForemanAzureRm
             pip = sdk.create_or_update_pip(args[:resource_group],
                                            "#{args[:vm_name]}-pip#{nic}",
                                            public_ip_params)
+            pips << pip
           end
           new_nic = sdk.create_or_update_nic(
             args[:resource_group],
@@ -167,7 +169,7 @@ module ForemanAzureRm
           )
           nics << new_nic
         end
-        nics
+        { nics: nics, pips: pips }
       end
 
       def initialize_vm(vm_hash)

--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -5,9 +5,9 @@ module ForemanAzureRm
       extend ActiveSupport::Concern
 
       def define_managed_storage_profile(vm_name, os_disk_caching, platform, premium_os_disk, os_disk_size_gb)
-        storage_profile = ComputeModels::StorageProfile.new
-        os_disk = ComputeModels::OSDisk.new
-        managed_disk_params = ComputeModels::ManagedDiskParameters.new
+        storage_profile = OpenStruct.new
+        os_disk = OpenStruct.new
+        managed_disk_params = OpenStruct.new
 
         # Create OS disk
         os_disk.name = "#{vm_name}-osdisk"
@@ -45,8 +45,8 @@ module ForemanAzureRm
           disks = []
           disk_count = 0
           data_disks.each do |disk_num, attrs|
-            managed_data_disk = ComputeModels::ManagedDiskParameters.new
-            disk = ComputeModels::DataDisk.new
+            managed_data_disk = OpenStruct.new
+            disk = OpenStruct.new
             disk.name = "#{vm_name}-data-disk#{disk_count}"
             disk.caching  = disk_caching(attrs[:data_disk_caching])
             disk.disk_size_gb = attrs[:disk_size_gb]
@@ -68,7 +68,7 @@ module ForemanAzureRm
         offer     = urn[1]
         sku       = urn[2]
         version   = urn[3]
-        image_plan = ComputeModels::PurchasePlan.new
+        image_plan = OpenStruct.new
         image_plan.publisher = publisher.downcase
         image_plan.name = sku.downcase
         image_plan.product = offer.downcase
@@ -76,7 +76,7 @@ module ForemanAzureRm
       end
 
       def marketplace_image_reference(publisher, offer, sku, version)
-        image_reference = ComputeModels::ImageReference.new
+        image_reference = OpenStruct.new
         image_reference.publisher = publisher
         image_reference.offer = offer
         image_reference.sku = sku
@@ -96,10 +96,10 @@ module ForemanAzureRm
           image_reference = marketplace_image_reference(publisher, offer, sku, version)
         when 'custom'
           custom_image = sdk.get_custom_image(rg_name, image_id)
-          image_reference = ComputeModels::ImageReference.new
+          image_reference = OpenStruct.new
           image_reference.id = custom_image.id
         when 'gallery'
-          image_reference = ComputeModels::ImageReference.new
+          image_reference = OpenStruct.new
           image_reference.id = sdk.fetch_gallery_image_id(rg_name, image_id)
         else
           image_reference = nil
@@ -110,12 +110,12 @@ module ForemanAzureRm
       def define_network_profile(network_interface_card_ids)
         network_interface_cards = []
         network_interface_card_ids.each_with_index do |id, index|
-          nic = ComputeModels::NetworkInterfaceReference.new
+          nic = OpenStruct.new
           nic.id = id
           nic.primary = true
           network_interface_cards << nic
         end
-        network_profile = ComputeModels::NetworkProfile.new
+        network_profile = OpenStruct.new
         network_profile.network_interfaces = network_interface_cards
         network_profile
       end
@@ -140,7 +140,7 @@ module ForemanAzureRm
                                     raise RuntimeError, "Public IP value must be either 'Dynamic', 'Static' or 'None'"
                                 end
           if pub_ip_alloc.present?
-            public_ip_params = NetworkModels::PublicIPAddress.new.tap do |ip|
+            public_ip_params = OpenStruct.new.tap do |ip|
               ip.location = region
               ip.public_ipallocation_method = pub_ip_alloc
             end
@@ -152,10 +152,10 @@ module ForemanAzureRm
           new_nic = sdk.create_or_update_nic(
             args[:resource_group],
             "#{args[:vm_name]}-nic#{nic}",
-            NetworkModels::NetworkInterface.new.tap do |interface|
+            OpenStruct.new.tap do |interface|
               interface.location = region
               interface.ip_configurations = [
-                NetworkModels::NetworkInterfaceIPConfiguration.new.tap do |nic_conf|
+                OpenStruct.new.tap do |nic_conf|
                   nic_conf.name = "#{args[:vm_name]}-nic#{nic}"
                   nic_conf.private_ipallocation_method = priv_ip_alloc
                   nic_conf.private_ipaddress = attrs[:ip] if priv_ip_alloc == "Static"
@@ -174,7 +174,7 @@ module ForemanAzureRm
         custom_data = vm_hash[:custom_data]
         msg = "Creating Virtual Machine #{vm_hash[:name]} in Resource Group #{vm_hash[:resource_group]}."
         logger.debug msg
-        vm_create_params = ComputeModels::VirtualMachine.new.tap do |vm|
+        vm_create_params = OpenStruct.new.tap do |vm|
           vm.location = vm_hash[:location]
           vm.tags = {}
           unless vm_hash[:tags].nil?
@@ -188,25 +188,25 @@ module ForemanAzureRm
             vm.availability_set = OpenStruct.new(id: vm_hash[:availability_set_id])
           end
 
-          vm.os_profile = ComputeModels::OSProfile.new.tap do |os_profile|
+          vm.os_profile = OpenStruct.new.tap do |os_profile|
             os_profile.computer_name  = vm_hash[:name]
             os_profile.admin_username = vm_hash[:username]
             os_profile.admin_password = vm_hash[:password]
 
             # Adding the ssh-key support for authentication
             if vm_hash[:platform] == 'Linux'
-              os_profile.linux_configuration = ComputeModels::LinuxConfiguration.new.tap do |linux|
+              os_profile.linux_configuration = OpenStruct.new.tap do |linux|
                 linux.disable_password_authentication = vm_hash[:disable_password_authentication]
-                linux.ssh = ComputeModels::SshConfiguration.new.tap do |ssh_config|
+                linux.ssh = OpenStruct.new.tap do |ssh_config|
                   ssh_config.public_keys = [
-                    ComputeModels::SshPublicKey.new.tap do |foreman_key|
+                    OpenStruct.new.tap do |foreman_key|
                       foreman_key.key_data = key_pair.public
                       foreman_key.path = "/home/#{vm_hash[:username]}/.ssh/authorized_keys"
                     end
                   ]
                   if vm_hash[:ssh_key_data].present?
                     key_data = vm_hash[:ssh_key_data]
-                    pub_key = ComputeModels::SshPublicKey.new
+                    pub_key = OpenStruct.new
                     pub_key.key_data = key_data
                     pub_key.path = "/home/#{vm_hash[:username]}/.ssh/authorized_keys"
                     ssh_config.public_keys << pub_key
@@ -224,7 +224,7 @@ module ForemanAzureRm
                                                                 vm_hash[:premium_os_disk],
                                                                 vm_hash[:os_disk_size_gb]
                                                               )
-          vm.hardware_profile = ComputeModels::HardwareProfile.new.tap do |hw_profile|
+          vm.hardware_profile = OpenStruct.new.tap do |hw_profile|
             hw_profile.vm_size = vm_hash[:vm_size]
           end
         end
@@ -244,7 +244,7 @@ module ForemanAzureRm
       def create_vm_extension(region, args = {})
         if args[:script_command].present? || args[:script_uris].present?
           args[:script_uris] ||=  args[:script_uris].to_s
-          extension = ComputeModels::VirtualMachineExtension.new
+          extension = OpenStruct.new
 
           case args[:platform]
           # https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux
@@ -278,7 +278,7 @@ module ForemanAzureRm
       end
 
       def create_vm_nvidia_gpu_extension(region, args = {})
-        extension = ComputeModels::VirtualMachineExtension.new
+        extension = OpenStruct.new
         extension.publisher = 'Microsoft.HpcCompute'
         extension.type_handler_version = '1.3'
         extension.auto_upgrade_minor_version = true

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -374,8 +374,16 @@ module ForemanAzureRm
       )
     rescue ForemanAzureRm::AzureApiError, RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)
-      nics&.each { |nic| sdk.delete_nic(args[:resource_group], nic.name) rescue nil }
-      destroy_vm(args[:vm_name]) rescue nil if args[:vm_name]
+      begin
+        destroy_vm(args[:vm_name]) if args[:vm_name]
+      rescue StandardError => cleanup_err
+        logger.warn("VM cleanup failed: #{cleanup_err.message}")
+      end
+      nics&.each do |nic|
+        sdk.delete_nic(args[:resource_group], nic.name) rescue nil
+        pip_name = "#{args[:vm_name]}-pip#{nic.name.split('-nic').last}"
+        sdk.delete_pip(args[:resource_group], pip_name) rescue nil
+      end
       raise e
     end
 

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -314,7 +314,9 @@ module ForemanAzureRm
     def create_vm(args = {})
       args = args.to_h.deep_symbolize_keys
       args[:vm_name] = args[:name].split('.')[0]
-      nics = create_nics(region, args)
+      created = create_nics(region, args)
+      nics = created[:nics]
+      pips = created[:pips]
       vm = nil
       user_command = args[:script_command]
 
@@ -374,16 +376,9 @@ module ForemanAzureRm
       )
     rescue ForemanAzureRm::AzureApiError, RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)
-      begin
-        destroy_vm(args[:vm_name]) if args[:vm_name]
-      rescue StandardError => cleanup_err
-        logger.warn("VM cleanup failed: #{cleanup_err.message}")
-      end
-      nics&.each do |nic|
-        sdk.delete_nic(args[:resource_group], nic.name) rescue nil
-        pip_name = "#{args[:vm_name]}-pip#{nic.name.split('-nic').last}"
-        sdk.delete_pip(args[:resource_group], pip_name) rescue nil
-      end
+      destroy_vm(args[:vm_name]) rescue nil if args[:vm_name]
+      nics&.each { |nic| sdk.delete_nic(args[:resource_group], nic.name) rescue nil }
+      pips&.each { |pip| sdk.delete_pip(args[:resource_group], pip.name) rescue nil }
       raise e
     end
 

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -171,40 +171,40 @@ module ForemanAzureRm
         end
       when 'gallery'
         begin
-          # Extract gallery name and image name from gallery:// URL
           gallery_parts = image_id.split('/')
-
           if gallery_parts.length >= 2
             gallery_name = gallery_parts[0]
             image_name = gallery_parts[1]
+          else
+            # Short format: gallery://image_name (emitted by image_uuid)
+            image_name = image_id
+            gallery_name = nil
+          end
 
-            # Try to find the gallery and image using dedicated SDK methods
-            galleries = sdk.list_galleries
-            gallery = galleries.find { |g| g.name == gallery_name }
+          galleries = sdk.list_galleries
+          galleries_to_check = if gallery_name
+                                 galleries.select { |g| g.name == gallery_name }
+                               else
+                                 galleries
+                               end
 
-            if gallery
-              rg_name = gallery.id.split('/')[4] # Extract resource group name from gallery ID
+          galleries_to_check.each do |gallery|
+            rg_name = gallery.id.split('/')[4]
+            begin
+              gallery_image = sdk.get_gallery_image(rg_name, gallery.name, image_name)
+              next unless gallery_image
 
-              # Check if the image exists in the gallery
-              begin
-                gallery_image = sdk.get_gallery_image(rg_name, gallery_name, image_name)
+              image_versions = sdk.list_gallery_image_versions(rg_name, gallery.name, image_name)
+              target_regions = image_versions.flat_map do |image_version|
+                image_version.publishing_profile.target_regions.map(&:name)
+              end.uniq.map { |tgt_reg| tgt_reg.gsub(/\s+/, '').downcase }
 
-                if gallery_image
-                  # Check versions and regions
-                  image_versions = sdk.list_gallery_image_versions(rg_name, gallery_name, image_name)
-                  target_regions = image_versions.map do |image_version|
-                    image_version.publishing_profile.target_regions.map(&:name)
-                  end.flatten.uniq.map { |tgt_reg| tgt_reg.gsub(/\s+/, '').downcase }
-
-                  return true if target_regions.include? region
-                end
-              rescue StandardError => e
-                Rails.logger.warn("Gallery image check failed: #{e.message}")
-              end
+              return true if target_regions.include?(region)
+            rescue StandardError => e
+              Rails.logger.warn("Gallery image check failed for #{gallery.name}/#{image_name}: #{e.message}")
             end
           end
 
-          # If any problems occur, assume the image doesn't exist
           return false
         rescue StandardError => e
           Rails.logger.warn("Gallery check failed: #{e.message}")
@@ -372,9 +372,10 @@ module ForemanAzureRm
         nvidia_gpu_extension: ActiveRecord::Type::Boolean.new.deserialize(args[:nvidia_gpu_extension]),
         tags: args[:tags],
       )
-    rescue AzureRestClient::AzureApiError, RuntimeError => e
+    rescue ForemanAzureRm::AzureApiError, RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)
-      destroy_vm(args[:vm_name]) if args[:vm_name]
+      nics&.each { |nic| sdk.delete_nic(args[:resource_group], nic.name) rescue nil }
+      destroy_vm(args[:vm_name]) rescue nil if args[:vm_name]
       raise e
     end
 

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -172,15 +172,6 @@ module ForemanAzureRm
           return false
         end
       when 'gallery'
-        # Instead of the problematic line:
-        # gallery_images_list = sdk.list_resources(filter: "resourceType eq 'Microsoft.Compute/galleries/images'")
-        #
-        # The issue occurs with azure_mgmt_resources 0.18.2, where the resources.list method
-        # signature has changed from previous versions. In prior versions, this method accepted
-        # a filter parameter directly (resources.list(filter: "...")) but in version 0.18.2,
-        # the method doesn't accept any parameters, causing the "wrong number of arguments (given 1, expected 0)"
-        # error. This change in the Ruby SDK API is likely due to Azure REST API updates.
-
         begin
           # Extract gallery name and image name from gallery:// URL
           gallery_parts = image_id.split('/')

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -376,21 +376,9 @@ module ForemanAzureRm
       )
     rescue ForemanAzureRm::AzureApiError, RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)
-      begin
-        destroy_vm(args[:vm_name]) if args[:vm_name]
-      rescue StandardError => cleanup_err
-        logger.warn("VM cleanup failed: #{cleanup_err.message}")
-      end
-      nics&.each do |nic|
-        sdk.delete_nic(args[:resource_group], nic.name)
-      rescue StandardError => nic_err
-        logger.warn("NIC cleanup failed for #{nic.name}: #{nic_err.message}")
-      end
-      pips&.each do |pip|
-        sdk.delete_pip(args[:resource_group], pip.name)
-      rescue StandardError => pip_err
-        logger.warn("PIP cleanup failed for #{pip.name}: #{pip_err.message}")
-      end
+      best_effort("VM cleanup") { destroy_vm(args[:vm_name]) } if args[:vm_name]
+      nics&.each { |nic| best_effort("NIC #{nic.name}") { sdk.delete_nic(args[:resource_group], nic.name) } }
+      pips&.each { |pip| best_effort("PIP #{pip.name}") { sdk.delete_pip(args[:resource_group], pip.name) } }
       raise e
     end
 
@@ -420,6 +408,14 @@ module ForemanAzureRm
     rescue ActiveRecord::RecordNotFound
       logger.info "Could not find the selected vm."
       true
+    end
+
+    private
+
+    def best_effort(description)
+      yield
+    rescue StandardError => e
+      logger.warn("#{description} failed: #{e.message}")
     end
   end
 end

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -7,6 +7,7 @@ module ForemanAzureRm
   class AzureRm < ComputeResource
 
     include VMExtensions::ManagedVM
+
     alias_attribute :sub_id, :user
     alias_attribute :secret_key, :password
     alias_attribute :region, :url
@@ -103,7 +104,7 @@ module ForemanAzureRm
       super
       errors[:user].empty? && errors[:password].empty? && errors[:uuid].empty? && errors[:app_ident].empty? && errors[:cloud].empty? && regions
     rescue StandardError => e
-      errors[:base] << e.message
+      errors.add(:base, e.message)
     end
 
     def new_vm(args = {})
@@ -111,7 +112,7 @@ module ForemanAzureRm
       opts = vm_instance_defaults.merge(args.to_h).deep_symbolize_keys
       # convert rails nested_attributes into a plain hash
       [:interfaces, :volumes].each do |collection|
-        nested_args = opts.delete("#{collection}_attributes".to_sym)
+        nested_args = opts.delete(:"#{collection}_attributes")
         opts[collection] = nested_attributes_for(collection, nested_args) if nested_args
       end
       opts.reject! { |k, v| v.nil? }

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -317,12 +317,12 @@ module ForemanAzureRm
       args = args.to_h.deep_symbolize_keys
       args[:vm_name] = args[:name].split('.')[0]
       nics = create_nics(region, args)
+      vm = nil
+      user_command = args[:script_command]
 
       if args[:platform] == 'Linux'
         if args[:password].present? && !args[:ssh_key_data].present?
           if args[:script_command].present?
-            # to run the script_cmd given through form as username
-            user_command = args[:script_command]
             args[:script_command] = "su - \"#{args[:username]}\" -c \"#{user_command}\""
           end
           disable_password_auth = false
@@ -374,9 +374,9 @@ module ForemanAzureRm
         nvidia_gpu_extension: ActiveRecord::Type::Boolean.new.deserialize(args[:nvidia_gpu_extension]),
         tags: args[:tags],
       )
-    rescue RuntimeError => e
+    rescue AzureRestClient::AzureApiError, RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)
-      destroy_vm vm.id if vm
+      destroy_vm(vm.id) if vm&.respond_to?(:id)
       raise e
     end
 

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -126,8 +126,8 @@ module ForemanAzureRm
                              os_disk_size_gb: opts[:os_disk_size_gb],
                              nvidia_gpu_extension: opts[:nvidia_gpu_extension],
                             )
+      ifaces = []
       if opts[:interfaces].present?
-        ifaces = []
         opts[:interfaces].each_with_index do |iface_attrs, i|
           ifaces << new_interface(iface_attrs)
         end

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -102,8 +102,6 @@ module ForemanAzureRm
       errors[:user].empty? && errors[:password].empty? && errors[:uuid].empty? && errors[:app_ident].empty? && errors[:cloud].empty? && regions
     rescue StandardError => e
       errors[:base] << e.message
-    rescue Excon::Error::Socket => e
-      errors[:base] << e.message
     end
 
     def new_vm(args = {})
@@ -376,7 +374,7 @@ module ForemanAzureRm
       )
     rescue AzureRestClient::AzureApiError, RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)
-      destroy_vm(vm.id) if vm&.respond_to?(:id)
+      destroy_vm(args[:vm_name]) if args[:vm_name]
       raise e
     end
 

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -376,9 +376,21 @@ module ForemanAzureRm
       )
     rescue ForemanAzureRm::AzureApiError, RuntimeError => e
       Foreman::Logging.exception('Unhandled AzureRm error', e)
-      destroy_vm(args[:vm_name]) rescue nil if args[:vm_name]
-      nics&.each { |nic| sdk.delete_nic(args[:resource_group], nic.name) rescue nil }
-      pips&.each { |pip| sdk.delete_pip(args[:resource_group], pip.name) rescue nil }
+      begin
+        destroy_vm(args[:vm_name]) if args[:vm_name]
+      rescue StandardError => cleanup_err
+        logger.warn("VM cleanup failed: #{cleanup_err.message}")
+      end
+      nics&.each do |nic|
+        sdk.delete_nic(args[:resource_group], nic.name)
+      rescue StandardError => nic_err
+        logger.warn("NIC cleanup failed for #{nic.name}: #{nic_err.message}")
+      end
+      pips&.each do |pip|
+        sdk.delete_pip(args[:resource_group], pip.name)
+      rescue StandardError => pip_err
+        logger.warn("PIP cleanup failed for #{pip.name}: #{pip_err.message}")
+      end
       raise e
     end
 

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -51,7 +51,9 @@ module ForemanAzureRm
     end
 
     def sdk
-      @sdk ||= ForemanAzureRm::AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id, azure_environment)
+      @sdk ||= ForemanAzureRm::AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id, azure_environment,
+                                                     proxy_url: connection_options[:proxy],
+                                                     ssl_cert_store: connection_options[:ssl_cert_store])
     end
 
     def to_label
@@ -90,7 +92,7 @@ module ForemanAzureRm
 
     def regions
       return unless sub_id.present?
-      sdk.list_regions(sub_id).value.map { |loc| [loc.display_name, loc.name] }
+      (sdk.list_regions(sub_id).value || []).map { |loc| [loc.display_name, loc.name] }
     end
 
     def resource_groups
@@ -171,44 +173,25 @@ module ForemanAzureRm
         end
       when 'gallery'
         begin
-          gallery_parts = image_id.split('/')
-          if gallery_parts.length >= 2
-            gallery_name = gallery_parts[0]
-            image_name = gallery_parts[1]
-          else
-            # Short format: gallery://image_name (emitted by image_uuid)
-            image_name = image_id
-            gallery_name = nil
-          end
+          resolved_id = sdk.fetch_gallery_image_id(nil, image_id)
+          return false unless resolved_id
 
-          galleries = sdk.list_galleries
-          galleries_to_check = if gallery_name
-                                 galleries.select { |g| g.name == gallery_name }
-                               else
-                                 galleries
-                               end
+          id_parts = resolved_id.split('/')
+          rg_name = id_parts[4]
+          gallery_name = id_parts[8]
+          image_name = id_parts[-1]
 
-          galleries_to_check.each do |gallery|
-            rg_name = gallery.id.split('/')[4]
-            begin
-              gallery_image = sdk.get_gallery_image(rg_name, gallery.name, image_name)
-              next unless gallery_image
+          image_versions = sdk.list_gallery_image_versions(rg_name, gallery_name, image_name)
+          target_regions = image_versions.flat_map do |image_version|
+            (image_version.publishing_profile&.target_regions || []).map(&:name)
+          end.uniq.map { |tgt_reg| tgt_reg.gsub(/\s+/, '').downcase }
 
-              image_versions = sdk.list_gallery_image_versions(rg_name, gallery.name, image_name)
-              target_regions = image_versions.flat_map do |image_version|
-                image_version.publishing_profile.target_regions.map(&:name)
-              end.uniq.map { |tgt_reg| tgt_reg.gsub(/\s+/, '').downcase }
-
-              return true if target_regions.include?(region)
-            rescue StandardError => e
-              Rails.logger.warn("Gallery image check failed for #{gallery.name}/#{image_name}: #{e.message}")
-            end
-          end
-
-          return false
+          target_regions.include?(region)
+        rescue ArgumentError => e
+          raise e
         rescue StandardError => e
           Rails.logger.warn("Gallery check failed: #{e.message}")
-          return false
+          false
         end
       when 'custom'
         custom_image = sdk.list_custom_images.detect { |custom_img| custom_img.name == image_id && custom_img.location == region }

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -11,7 +11,7 @@ module ForemanAzureRm
 
     delegate :name, to: :azure_vm, allow_nil: true
 
-    def initialize(azure_vm: ComputeModels::VirtualMachine.new,
+    def initialize(azure_vm: OpenStruct.new,
                    sdk: nil,
                    resource_group: azure_vm.resource_group,
                    nics: [],
@@ -30,14 +30,14 @@ module ForemanAzureRm
       @script_uris ||= script_uris
       @nvidia_gpu_extension ||= nvidia_gpu_extension
       @tags ||= tags
-      @azure_vm.hardware_profile ||= ComputeModels::HardwareProfile.new
-      @azure_vm.os_profile ||= ComputeModels::OSProfile.new
-      @azure_vm.os_profile.linux_configuration ||= ComputeModels::LinuxConfiguration.new
-      @azure_vm.os_profile.linux_configuration.ssh ||= ComputeModels::SshConfiguration.new
-      @azure_vm.os_profile.linux_configuration.ssh.public_keys ||= [ComputeModels::SshPublicKey.new]
-      @azure_vm.storage_profile ||= ComputeModels::StorageProfile.new
-      @azure_vm.storage_profile.os_disk ||= ComputeModels::OSDisk.new
-      @azure_vm.storage_profile.os_disk.managed_disk ||= ComputeModels::ManagedDiskParameters.new
+      @azure_vm.hardware_profile ||= OpenStruct.new
+      @azure_vm.os_profile ||= OpenStruct.new
+      @azure_vm.os_profile.linux_configuration ||= OpenStruct.new
+      @azure_vm.os_profile.linux_configuration.ssh ||= OpenStruct.new
+      @azure_vm.os_profile.linux_configuration.ssh.public_keys ||= [OpenStruct.new]
+      @azure_vm.storage_profile ||= OpenStruct.new
+      @azure_vm.storage_profile.os_disk ||= OpenStruct.new
+      @azure_vm.storage_profile.os_disk.managed_disk ||= OpenStruct.new
     end
 
     def id

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -240,8 +240,9 @@ module ForemanAzureRm
         cmd = vm_extension.settings&.command_to_execute
         return @script_command if cmd.blank? || cmd.ends_with?("waagent")
         if ssh_key_data.nil? && platform == 'Linux'
-          user_cmd_index = (cmd.index("-c") || 0) + 4
-          cmd[user_cmd_index..-2]
+          c_index = cmd.index("-c")
+          return cmd unless c_index
+          cmd[c_index + 4..-2]
         else
           cmd
         end

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -20,7 +20,6 @@ module ForemanAzureRm
                    script_uris: nil,
                    nvidia_gpu_extension: false,
                    tags: [])
-
       @azure_vm = azure_vm
       @sdk = sdk
       @resource_group ||= resource_group
@@ -40,9 +39,7 @@ module ForemanAzureRm
       @azure_vm.storage_profile.os_disk.managed_disk ||= OpenStruct.new
     end
 
-    def id
-      @azure_vm.id
-    end
+    delegate :id, to: :@azure_vm
 
     def persisted?
       !!identity && !!id
@@ -245,7 +242,7 @@ module ForemanAzureRm
         if ssh_key_data.nil? && platform == 'Linux'
           c_index = cmd.index("-c")
           return cmd unless c_index
-          cmd[c_index + 4..-2]
+          cmd[(c_index + 4)..-2]
         else
           cmd
         end
@@ -257,18 +254,14 @@ module ForemanAzureRm
     def script_uris
       if vm_extension.present?
         uris = vm_extension.settings&.file_uris
-        uris.present? ? uris : @script_uris
+        uris.presence || @script_uris
       else
         @script_uris
       end
     end
 
     def nvidia_gpu_extension
-      if vm_nvidia_gpu_extension.present?
-        true
-      else
-        @nvidia_gpu_extension
-      end
+      vm_nvidia_gpu_extension.present? || @nvidia_gpu_extension
     end
 
   end

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -237,15 +237,13 @@ module ForemanAzureRm
 
     def script_command
       if vm_extension.present?
-        return @script_command if vm_extension.settings.command_to_execute.ends_with?("waagent")
-        # Index is based on script_command that is being injected
-        # from the code in #create_vm. It can be partly hard-coded
-        # since the command shall no change frequently.
+        cmd = vm_extension.settings&.command_to_execute
+        return @script_command if cmd.blank? || cmd.ends_with?("waagent")
         if ssh_key_data.nil? && platform == 'Linux'
-          user_cmd_index = (vm_extension.settings.command_to_execute.index("-c"))+ 4
-          script_command = vm_extension.settings.command_to_execute[user_cmd_index..-2]
+          user_cmd_index = (cmd.index("-c") || 0) + 4
+          cmd[user_cmd_index..-2]
         else
-          vm_extension.settings.command_to_execute
+          cmd
         end
       else
         @script_command
@@ -254,8 +252,8 @@ module ForemanAzureRm
 
     def script_uris
       if vm_extension.present?
-        return @script_uris unless vm_extension.settings.file_uris
-        script_uris = vm_extension.settings.file_uris
+        uris = vm_extension.settings&.file_uris
+        uris.present? ? uris : @script_uris
       else
         @script_uris
       end

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -199,12 +199,15 @@ module ForemanAzureRm
       if image.id.nil?
         return "marketplace://#{image.publisher}:#{image.offer}:#{image.sku}:#{image.version}"
       else
-        image_rg = image.id.split('/')[4]
-        image_name = image.id.split('/')[-1]
+        parts = image.id.split('/')
+        image_rg = parts[4]
+        image_name = parts[-1]
+        if image.id.include?('/galleries/')
+          gallery_name = parts[8]
+          return "gallery://#{image_rg}/#{gallery_name}/#{image_name}"
+        end
         if sdk.list_custom_images.find { |custom_img| custom_img.name == image_name }
           return "custom://#{image_name}"
-        elsif sdk.fetch_gallery_image_id(image_rg, image_name)
-          return "gallery://#{image_name}"
         end
       end
     end

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -237,15 +237,15 @@ module ForemanAzureRm
 
     def script_command
       if vm_extension.present?
-        return @script_command if vm_extension.settings["commandToExecute"].ends_with?("waagent")
+        return @script_command if vm_extension.settings.command_to_execute.ends_with?("waagent")
         # Index is based on script_command that is being injected
         # from the code in #create_vm. It can be partly hard-coded
         # since the command shall no change frequently.
         if ssh_key_data.nil? && platform == 'Linux'
-          user_cmd_index = (vm_extension.settings["commandToExecute"].index("-c"))+ 4
-          script_command = vm_extension.settings["commandToExecute"][user_cmd_index..-2]
+          user_cmd_index = (vm_extension.settings.command_to_execute.index("-c"))+ 4
+          script_command = vm_extension.settings.command_to_execute[user_cmd_index..-2]
         else
-          vm_extension.settings["commandToExecute"]
+          vm_extension.settings.command_to_execute
         end
       else
         @script_command
@@ -254,8 +254,8 @@ module ForemanAzureRm
 
     def script_uris
       if vm_extension.present?
-        return @script_uris unless vm_extension.settings["fileUris"]
-        script_uris = vm_extension.settings["fileUris"]
+        return @script_uris unless vm_extension.settings.file_uris
+        script_uris = vm_extension.settings.file_uris
       else
         @script_uris
       end

--- a/foreman_azure_rm.gemspec
+++ b/foreman_azure_rm.gemspec
@@ -12,9 +12,6 @@ Gem::Specification.new do |s|
   s.files   = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.description = 'This gem provides Azure Resource Manager as a compute resource for The Foreman'
 
-  s.add_dependency 'azure_mgmt_resources', '~> 0.18.1'
-  s.add_dependency 'azure_mgmt_network', '~> 0.26.1'
-  s.add_dependency 'azure_mgmt_storage', '~> 0.23.0'
-  s.add_dependency 'azure_mgmt_compute', '~> 0.22.0'
-  s.add_dependency 'azure_mgmt_subscriptions', '~> 0.18.5'
+  # Azure SDK for Ruby was retired (Dec 2021, archived Jan 2023).
+  # This plugin now uses direct Azure REST API calls via Net::HTTP.
 end

--- a/lib/foreman_azure_rm.rb
+++ b/lib/foreman_azure_rm.rb
@@ -2,23 +2,27 @@ require 'foreman_azure_rm/engine.rb'
 
 module ForemanAzureRm
   module ComputeModels
-    CachingTypes = OpenStruct.new(
-      None: 'None',
-      ReadOnly: 'ReadOnly',
-      ReadWrite: 'ReadWrite'
-    )
-    DiskCreateOption = OpenStruct.new(Empty: 'Empty')
-    DiskCreateOptionTypes = OpenStruct.new(FromImage: 'FromImage')
-    StorageAccountTypes = OpenStruct.new(
-      PremiumLRS: 'Premium_LRS',
-      StandardLRS: 'Standard_LRS'
-    )
+    module CachingTypes
+      None = 'None'
+      ReadOnly = 'ReadOnly'
+      ReadWrite = 'ReadWrite'
+    end
+    module DiskCreateOption
+      Empty = 'Empty'
+    end
+    module DiskCreateOptionTypes
+      FromImage = 'FromImage'
+    end
+    module StorageAccountTypes
+      PremiumLRS = 'Premium_LRS'
+      StandardLRS = 'Standard_LRS'
+    end
   end
 
   module NetworkModels
-    IPAllocationMethod = OpenStruct.new(
-      Dynamic: 'Dynamic',
-      Static: 'Static'
-    )
+    module IPAllocationMethod
+      Dynamic = 'Dynamic'
+      Static = 'Static'
+    end
   end
 end

--- a/lib/foreman_azure_rm.rb
+++ b/lib/foreman_azure_rm.rb
@@ -3,26 +3,29 @@ require 'foreman_azure_rm/engine.rb'
 module ForemanAzureRm
   module ComputeModels
     module CachingTypes
-      None = 'None'
-      ReadOnly = 'ReadOnly'
-      ReadWrite = 'ReadWrite'
+      None = 'None'.freeze
+      ReadOnly = 'ReadOnly'.freeze
+      ReadWrite = 'ReadWrite'.freeze
     end
+
     module DiskCreateOption
-      Empty = 'Empty'
+      Empty = 'Empty'.freeze
     end
+
     module DiskCreateOptionTypes
-      FromImage = 'FromImage'
+      FromImage = 'FromImage'.freeze
     end
+
     module StorageAccountTypes
-      PremiumLRS = 'Premium_LRS'
-      StandardLRS = 'Standard_LRS'
+      PremiumLRS = 'Premium_LRS'.freeze
+      StandardLRS = 'Standard_LRS'.freeze
     end
   end
 
   module NetworkModels
     module IPAllocationMethod
-      Dynamic = 'Dynamic'
-      Static = 'Static'
+      Dynamic = 'Dynamic'.freeze
+      Static = 'Static'.freeze
     end
   end
 end

--- a/lib/foreman_azure_rm.rb
+++ b/lib/foreman_azure_rm.rb
@@ -1,20 +1,42 @@
 require 'foreman_azure_rm/engine.rb'
-require 'azure_mgmt_resources'
-require 'azure_mgmt_network'
-require 'azure_mgmt_storage'
-require 'azure_mgmt_compute'
-require 'azure_mgmt_subscriptions'
 
 module ForemanAzureRm
-  Storage = Azure::Storage::Profiles::Latest::Mgmt
-  Network = Azure::Network::Profiles::Latest::Mgmt
-  Compute = Azure::Compute::Profiles::Latest::Mgmt
-  Resources = Azure::Resources::Profiles::Latest::Mgmt
-  Subscriptions = Azure::Subscriptions::Profiles::Latest::Mgmt
+  module ComputeModels
+    CachingTypes = OpenStruct.new(
+      None: 'None',
+      ReadOnly: 'ReadOnly',
+      ReadWrite: 'ReadWrite'
+    )
+    DiskCreateOption = OpenStruct.new(Empty: 'Empty')
+    DiskCreateOptionTypes = OpenStruct.new(FromImage: 'FromImage')
+    StorageAccountTypes = OpenStruct.new(
+      PremiumLRS: 'Premium_LRS',
+      StandardLRS: 'Standard_LRS'
+    )
+    VirtualMachine = OpenStruct
+    VirtualMachineExtension = OpenStruct
+    HardwareProfile = OpenStruct
+    OSProfile = OpenStruct
+    LinuxConfiguration = OpenStruct
+    SshConfiguration = OpenStruct
+    SshPublicKey = OpenStruct
+    StorageProfile = OpenStruct
+    OSDisk = OpenStruct
+    ManagedDiskParameters = OpenStruct
+    DataDisk = OpenStruct
+    ImageReference = OpenStruct
+    PurchasePlan = OpenStruct
+    NetworkInterfaceReference = OpenStruct
+    NetworkProfile = OpenStruct
+  end
 
-  StorageModels = Storage::Models
-  NetworkModels = Network::Models
-  ComputeModels = Compute::Models
-  ResourceModels = Resources::Models
-  SubscriptionModels = Subscriptions::Models
+  module NetworkModels
+    IPAllocationMethod = OpenStruct.new(
+      Dynamic: 'Dynamic',
+      Static: 'Static'
+    )
+    NetworkInterface = OpenStruct
+    NetworkInterfaceIPConfiguration = OpenStruct
+    PublicIPAddress = OpenStruct
+  end
 end

--- a/lib/foreman_azure_rm.rb
+++ b/lib/foreman_azure_rm.rb
@@ -13,21 +13,6 @@ module ForemanAzureRm
       PremiumLRS: 'Premium_LRS',
       StandardLRS: 'Standard_LRS'
     )
-    VirtualMachine = OpenStruct
-    VirtualMachineExtension = OpenStruct
-    HardwareProfile = OpenStruct
-    OSProfile = OpenStruct
-    LinuxConfiguration = OpenStruct
-    SshConfiguration = OpenStruct
-    SshPublicKey = OpenStruct
-    StorageProfile = OpenStruct
-    OSDisk = OpenStruct
-    ManagedDiskParameters = OpenStruct
-    DataDisk = OpenStruct
-    ImageReference = OpenStruct
-    PurchasePlan = OpenStruct
-    NetworkInterfaceReference = OpenStruct
-    NetworkProfile = OpenStruct
   end
 
   module NetworkModels
@@ -35,8 +20,5 @@ module ForemanAzureRm
       Dynamic: 'Dynamic',
       Static: 'Static'
     )
-    NetworkInterface = OpenStruct
-    NetworkInterfaceIPConfiguration = OpenStruct
-    PublicIPAddress = OpenStruct
   end
 end

--- a/lib/foreman_azure_rm/engine.rb
+++ b/lib/foreman_azure_rm/engine.rb
@@ -32,18 +32,9 @@ module ForemanAzureRm
     end
 
     config.to_prepare do
-      require 'azure_mgmt_resources'
-      require 'azure_mgmt_network'
-      require 'azure_mgmt_storage'
-      require 'azure_mgmt_compute'
-      require 'azure_mgmt_subscriptions'
-
       # Add format validation for azure images
       ::Image.validates :uuid, uniqueness: { scope: :compute_resource_id, case_sensitive: false }, format: { with: /\A((marketplace|custom|gallery):\/\/)[^:]+(:[^:]+:[^:]+:[^:]+)?\z/,
           message: "Incorrect UUID format" }, if: -> (image){ image.compute_resource.is_a? ForemanAzureRm::AzureRm }
-
-      # Use excon as default so that HTTP Proxy settings of foreman works
-      Faraday::default_adapter=:excon
 
       ::HostsController.send(:include, ForemanAzureRm::Concerns::HostsControllerExtensions)
 

--- a/test/unit/azure_rest_client_test.rb
+++ b/test/unit/azure_rest_client_test.rb
@@ -52,24 +52,70 @@ class AzureRestClientTest < ActiveSupport::TestCase
     assert_equal 'Standard_A0', result.vm_size
   end
 
-  test "wraps nested JSON with recursive OpenStruct" do
+  test "flattens properties and fixes field names on inbound VM response" do
+    vm_json = {
+      'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/test-vm',
+      'name' => 'test-vm',
+      'location' => 'eastus',
+      'properties' => {
+        'hardwareProfile' => { 'vmSize' => 'Standard_B2s' },
+        'storageProfile' => {
+          'osDisk' => { 'diskSizeGB' => 30, 'osType' => 'Linux', 'caching' => 'ReadWrite' },
+          'imageReference' => { 'publisher' => 'Canonical', 'offer' => 'UbuntuServer', 'sku' => '18.04-LTS', 'version' => 'latest' },
+        },
+        'osProfile' => { 'adminUsername' => 'azureuser' },
+        'networkProfile' => {
+          'networkInterfaces' => [{ 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic0' }],
+        },
+      },
+    }
+
     stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
-      .to_return(
-        body: {
+      .to_return(body: vm_json.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    vm = @client.get('/test', api_version: '2023-01-01')
+
+    assert_equal 'test-vm', vm.name
+    assert_equal 'eastus', vm.location
+    assert_equal 'my-rg', vm.resource_group
+    assert_equal 'Standard_B2s', vm.hardware_profile.vm_size
+    assert_equal 30, vm.storage_profile.os_disk.disk_size_gb
+    assert_equal 'Linux', vm.storage_profile.os_disk.os_type
+    assert_equal 'azureuser', vm.os_profile.admin_username
+    assert_equal 'Canonical', vm.storage_profile.image_reference.publisher
+    assert_equal 1, vm.network_profile.network_interfaces.length
+  end
+
+  test "flattens nested properties on inbound NIC response" do
+    nic_json = {
+      'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic0',
+      'name' => 'nic0',
+      'properties' => {
+        'ipConfigurations' => [{
+          'name' => 'ipconfig1',
           'properties' => {
-            'hardwareProfile' => { 'vmSize' => 'Standard_B2s' },
-            'storageProfile' => {
-              'osDisk' => { 'diskSizeGb' => 30 },
-            },
+            'privateIPAddress' => '10.0.0.4',
+            'privateIPAllocationMethod' => 'Dynamic',
+            'publicIPAddress' => { 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip0' },
+            'subnet' => { 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default' },
+            'primary' => true,
           },
-        }.to_json,
-        headers: { 'Content-Type' => 'application/json' }
-      )
+        }],
+      },
+    }
 
-    result = @client.get('/test', api_version: '2023-01-01')
+    stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
+      .to_return(body: nic_json.to_json, headers: { 'Content-Type' => 'application/json' })
 
-    assert_equal 'Standard_B2s', result.properties.hardware_profile.vm_size
-    assert_equal 30, result.properties.storage_profile.os_disk.disk_size_gb
+    nic = @client.get('/test', api_version: '2023-01-01')
+
+    assert_equal 'nic0', nic.name
+    assert_equal 'my-rg', nic.resource_group
+    ip_config = nic.ip_configurations.first
+    assert_equal '10.0.0.4', ip_config.private_ipaddress
+    assert_equal 'Dynamic', ip_config.private_ipallocation_method
+    assert ip_config.public_ipaddress.id.include?('pip0')
+    assert_equal true, ip_config.primary
   end
 
   test "raises AzureApiError on 4xx/5xx" do
@@ -96,15 +142,142 @@ class AzureRestClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "serializes OpenStruct body with camelCase keys" do
+  test "serializes OpenStruct body with ARM properties envelope" do
     stub_request(:put, "#{@base_url}/test?api-version=2023-01-01")
-      .with { |req| JSON.parse(req.body)['vmSize'] == 'Standard_A0' }
+      .with do |req|
+        body = JSON.parse(req.body)
+        body.dig('properties', 'vmSize') == 'Standard_A0'
+      end
       .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
 
     body = OpenStruct.new(vm_size: 'Standard_A0')
     @client.put('/test', body, api_version: '2023-01-01')
 
     assert_requested :put, "#{@base_url}/test?api-version=2023-01-01"
+  end
+
+  test "outbound VM body has correct ARM shape" do
+    stub_request(:put, /#{@base_url}/)
+      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+    vm = OpenStruct.new(
+      location: 'eastus',
+      tags: { 'env' => 'test' },
+      hardware_profile: OpenStruct.new(vm_size: 'Standard_B2s'),
+      storage_profile: OpenStruct.new(
+        os_disk: OpenStruct.new(disk_size_gb: 30, create_option: 'FromImage')
+      ),
+      os_profile: OpenStruct.new(admin_username: 'azureuser', admin_password: 'secret'),
+      network_profile: OpenStruct.new(
+        network_interfaces: [OpenStruct.new(id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic0', primary: true)]
+      ),
+    )
+    @client.put('/test', vm, api_version: '2023-01-01')
+
+    assert_requested :put, /#{@base_url}/ do |req|
+      body = JSON.parse(req.body)
+      assert_equal 'eastus', body['location']
+      assert_equal({ 'env' => 'test' }, body['tags'])
+      assert_equal 'Standard_B2s', body.dig('properties', 'hardwareProfile', 'vmSize')
+      assert_equal 30, body.dig('properties', 'storageProfile', 'osDisk', 'diskSizeGB')
+      assert_equal 'FromImage', body.dig('properties', 'storageProfile', 'osDisk', 'createOption')
+      assert_equal 'azureuser', body.dig('properties', 'osProfile', 'adminUsername')
+      nic_ref = body.dig('properties', 'networkProfile', 'networkInterfaces', 0)
+      assert nic_ref['id'].include?('nic0')
+      assert_equal true, nic_ref.dig('properties', 'primary')
+    end
+  end
+
+  test "outbound NIC body uses correct Azure field names" do
+    stub_request(:put, /#{@base_url}/)
+      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+    nic = OpenStruct.new(
+      location: 'eastus',
+      ip_configurations: [
+        OpenStruct.new(
+          name: 'ipconfig1',
+          private_ipallocation_method: 'Dynamic',
+          private_ipaddress: '10.0.0.4',
+          public_ipaddress: OpenStruct.new(id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip0'),
+          subnet: OpenStruct.new(id: '/sub/net'),
+        ),
+      ],
+    )
+    @client.put('/test', nic, api_version: '2023-01-01')
+
+    assert_requested :put, /#{@base_url}/ do |req|
+      body = JSON.parse(req.body)
+      assert_equal 'eastus', body['location']
+      ip_conf = body.dig('properties', 'ipConfigurations', 0)
+      assert_equal 'ipconfig1', ip_conf['name']
+      assert_equal 'Dynamic', ip_conf.dig('properties', 'privateIPAllocationMethod')
+      assert_equal '10.0.0.4', ip_conf.dig('properties', 'privateIPAddress')
+      assert ip_conf.dig('properties', 'publicIPAddress', 'id')&.include?('pip0')
+      assert ip_conf.dig('properties', 'subnet', 'id') == '/sub/net'
+    end
+  end
+
+  test "outbound PIP body uses publicIPAllocationMethod" do
+    stub_request(:put, /#{@base_url}/)
+      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+    pip = OpenStruct.new(location: 'eastus', public_ipallocation_method: 'Static')
+    @client.put('/test', pip, api_version: '2023-01-01')
+
+    assert_requested :put, /#{@base_url}/ do |req|
+      body = JSON.parse(req.body)
+      assert_equal 'eastus', body['location']
+      assert_equal 'Static', body.dig('properties', 'publicIPAllocationMethod')
+    end
+  end
+
+  test "outbound extension maps virtual_machine_extension_type to properties.type" do
+    stub_request(:put, /#{@base_url}/)
+      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+    ext = OpenStruct.new(
+      location: 'eastus',
+      publisher: 'Microsoft.Azure.Extensions',
+      virtual_machine_extension_type: 'CustomScript',
+      type_handler_version: '2.0',
+      auto_upgrade_minor_version: true,
+      settings: { 'commandToExecute' => 'echo hello' },
+    )
+    @client.put('/test', ext, api_version: '2023-01-01')
+
+    assert_requested :put, /#{@base_url}/ do |req|
+      body = JSON.parse(req.body)
+      assert_equal 'eastus', body['location']
+      assert_equal 'Microsoft.Azure.Extensions', body.dig('properties', 'publisher')
+      assert_equal 'CustomScript', body.dig('properties', 'type')
+      assert_equal '2.0', body.dig('properties', 'typeHandlerVersion')
+      assert_equal true, body.dig('properties', 'autoUpgradeMinorVersion')
+      assert_equal 'echo hello', body.dig('properties', 'settings', 'commandToExecute')
+    end
+  end
+
+  test "injects resource_group on items in paginated list responses" do
+    page_url = "#{@base_url}/items?api-version=2023-01-01"
+
+    stub_request(:get, page_url)
+      .to_return(
+        body: {
+          'value' => [
+            { 'id' => '/subscriptions/test-sub/resourceGroups/rg-a/providers/Microsoft.Network/virtualNetworks/vnet1', 'name' => 'vnet1', 'location' => 'eastus' },
+            { 'id' => '/subscriptions/test-sub/resourceGroups/rg-b/providers/Microsoft.Network/virtualNetworks/vnet2', 'name' => 'vnet2', 'location' => 'westus' },
+          ],
+        }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    results = @client.get_paged('/items', api_version: '2023-01-01')
+
+    assert_equal 2, results.length
+    assert_equal 'rg-a', results[0].resource_group
+    assert_equal 'vnet1', results[0].name
+    assert_equal 'rg-b', results[1].resource_group
+    assert_equal 'vnet2', results[1].name
   end
 
   test "polls async operation on 202 Accepted and returns resource" do
@@ -126,7 +299,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
     stub_request(:get, resource_url)
       .to_return(body: { name: 'test-vm', location: 'eastus' }.to_json, headers: { 'Content-Type' => 'application/json' })
 
-    result = @client.put(resource_url, { name: 'test-vm' })
+    result = @client.put(resource_url, { name: 'test-vm' }, api_version: nil)
 
     assert_equal 'test-vm', result.name
     assert_equal 'eastus', result.location
@@ -145,7 +318,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
                  headers: { 'Content-Type' => 'application/json' })
 
     error = assert_raises(ForemanAzureRm::AzureApiError) do
-      @client.put(resource_url, {})
+      @client.put(resource_url, {}, api_version: nil)
     end
     assert_match(/Failed/, error.message)
     assert_match(/Quota exceeded/, error.message)
@@ -162,9 +335,54 @@ class AzureRestClientTest < ActiveSupport::TestCase
       .to_return(status: 500, body: 'Internal Server Error')
 
     error = assert_raises(ForemanAzureRm::AzureApiError) do
-      @client.put(resource_url, {})
+      @client.put(resource_url, {}, api_version: nil)
     end
     assert_equal 500, error.status_code
+  end
+
+  test "polls async operation on 201 Created with Azure-AsyncOperation header" do
+    resource_url = "#{@base_url}/subscriptions/test-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/test-vm?api-version=2023-03-01"
+    poll_url = "#{@base_url}/subscriptions/test-sub/providers/Microsoft.Compute/locations/eastus/operations/op-201"
+
+    stub_request(:put, resource_url)
+      .to_return(
+        status: 201,
+        body: { 'name' => 'test-vm', 'properties' => { 'provisioningState' => 'Creating' } }.to_json,
+        headers: { 'Azure-AsyncOperation' => poll_url, 'Content-Type' => 'application/json' }
+      )
+
+    stub_request(:get, poll_url)
+      .to_return(body: { status: 'Succeeded' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    stub_request(:get, resource_url)
+      .to_return(
+        body: { 'name' => 'test-vm', 'location' => 'eastus', 'properties' => { 'provisioningState' => 'Succeeded' } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    result = @client.put(resource_url, { name: 'test-vm' }, api_version: nil)
+
+    assert_equal 'test-vm', result.name
+    assert_equal 'eastus', result.location
+    assert_requested :get, poll_url, times: 1
+    assert_requested :get, resource_url, times: 1
+  end
+
+  test "async delete does not GET the deleted resource" do
+    resource_url = "#{@base_url}/subscriptions/test-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/test-vm?api-version=2023-03-01"
+    poll_url = "#{@base_url}/subscriptions/test-sub/providers/Microsoft.Compute/locations/eastus/operations/op-del"
+
+    stub_request(:delete, resource_url)
+      .to_return(status: 202, headers: { 'Azure-AsyncOperation' => poll_url })
+
+    stub_request(:get, poll_url)
+      .to_return(body: { status: 'Succeeded' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    result = @client.delete(resource_url, api_version: nil)
+
+    assert_nil result
+    assert_requested :get, poll_url, times: 1
+    assert_not_requested :get, resource_url
   end
 
   test "follows HTTP redirects" do
@@ -181,6 +399,25 @@ class AzureRestClientTest < ActiveSupport::TestCase
 
     assert_equal 'redirected', result.name
     assert_requested :get, redirect_url
+  end
+
+  test "polls Location-style async operation (202 then 200)" do
+    resource_url = "#{@base_url}/subscriptions/test-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/test-vm?api-version=2024-07-01"
+    location_url = "#{@base_url}/subscriptions/test-sub/providers/Microsoft.Compute/locations/eastus/operations/op-loc?monitor=true"
+
+    stub_request(:put, resource_url)
+      .to_return(status: 202, headers: { 'Location' => location_url })
+
+    stub_request(:get, location_url)
+      .to_return(
+        { status: 202, headers: { 'Content-Type' => 'application/json' } },
+        { status: 200, body: { 'name' => 'test-vm', 'location' => 'eastus' }.to_json, headers: { 'Content-Type' => 'application/json' } }
+      )
+
+    result = @client.put(resource_url, { name: 'test-vm' }, api_version: nil)
+
+    assert_equal 'test-vm', result.name
+    assert_requested :get, location_url, times: 2
   end
 
   test "paginates with get_paged" do
@@ -204,5 +441,69 @@ class AzureRestClientTest < ActiveSupport::TestCase
     assert_equal 2, results.length
     assert_equal 'item1', results[0].name
     assert_equal 'item2', results[1].name
+  end
+
+  test "raises AzureApiError when final GET after async Succeeded returns non-2xx" do
+    resource_url = "#{@base_url}/subscriptions/test-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/test-vm?api-version=2023-03-01"
+    poll_url = "#{@base_url}/subscriptions/test-sub/providers/Microsoft.Compute/locations/eastus/operations/op-gone"
+
+    stub_request(:put, resource_url)
+      .to_return(status: 202, headers: { 'Azure-AsyncOperation' => poll_url })
+
+    stub_request(:get, poll_url)
+      .to_return(body: { status: 'Succeeded' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    stub_request(:get, resource_url)
+      .to_return(status: 404, body: { error: { code: 'ResourceNotFound', message: 'Not found' } }.to_json)
+
+    error = assert_raises(ForemanAzureRm::AzureApiError) do
+      @client.put(resource_url, { name: 'test-vm' }, api_version: nil)
+    end
+    assert_equal 404, error.status_code
+    assert_match(/Final resource fetch failed/, error.message)
+  end
+
+  test "raises AzureApiError on non-JSON async poll body instead of timing out" do
+    resource_url = "#{@base_url}/test?api-version=2023-01-01"
+    poll_url = "#{@base_url}/operations/op-bad-json"
+
+    stub_request(:put, resource_url)
+      .to_return(status: 202, headers: { 'Azure-AsyncOperation' => poll_url })
+
+    stub_request(:get, poll_url)
+      .to_return(body: '<html>Bad Gateway</html>', headers: { 'Content-Type' => 'text/html' })
+
+    error = assert_raises(ForemanAzureRm::AzureApiError) do
+      @client.put(resource_url, {}, api_version: nil)
+    end
+    assert_match(/non-JSON/, error.message)
+  end
+
+  test "raises AzureApiError when poll response is missing status field" do
+    resource_url = "#{@base_url}/test?api-version=2023-01-01"
+    poll_url = "#{@base_url}/operations/op-no-status"
+
+    stub_request(:put, resource_url)
+      .to_return(status: 202, headers: { 'Azure-AsyncOperation' => poll_url })
+
+    stub_request(:get, poll_url)
+      .to_return(body: { result: 'ok' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    error = assert_raises(ForemanAzureRm::AzureApiError) do
+      @client.put(resource_url, {}, api_version: nil)
+    end
+    assert_match(/missing 'status'/, error.message)
+  end
+
+  test "handles null value in paginated response" do
+    stub_request(:get, "#{@base_url}/items?api-version=2023-01-01")
+      .to_return(
+        body: { value: nil }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    results = @client.get_paged('/items', api_version: '2023-01-01')
+
+    assert_equal [], results
   end
 end

--- a/test/unit/azure_rest_client_test.rb
+++ b/test/unit/azure_rest_client_test.rb
@@ -61,13 +61,13 @@ class AzureRestClientTest < ActiveSupport::TestCase
         'hardwareProfile' => { 'vmSize' => 'Standard_B2s' },
         'storageProfile' => {
           'osDisk' => { 'diskSizeGB' => 30, 'osType' => 'Linux', 'caching' => 'ReadWrite' },
-          'imageReference' => { 'publisher' => 'Canonical', 'offer' => 'UbuntuServer', 'sku' => '18.04-LTS', 'version' => 'latest' },
+          'imageReference' => { 'publisher' => 'Canonical', 'offer' => 'UbuntuServer', 'sku' => '18.04-LTS', 'version' => 'latest' }
         },
         'osProfile' => { 'adminUsername' => 'azureuser' },
         'networkProfile' => {
-          'networkInterfaces' => [{ 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic0' }],
-        },
-      },
+          'networkInterfaces' => [{ 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic0' }]
+        }
+      }
     }
 
     stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
@@ -98,10 +98,10 @@ class AzureRestClientTest < ActiveSupport::TestCase
             'privateIPAllocationMethod' => 'Dynamic',
             'publicIPAddress' => { 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip0' },
             'subnet' => { 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default' },
-            'primary' => true,
-          },
-        }],
-      },
+            'primary' => true
+          }
+        }]
+      }
     }
 
     stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
@@ -115,7 +115,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
     assert_equal '10.0.0.4', ip_config.private_ipaddress
     assert_equal 'Dynamic', ip_config.private_ipallocation_method
     assert ip_config.public_ipaddress.id.include?('pip0')
-    assert_equal true, ip_config.primary
+    assert ip_config.primary
   end
 
   test "raises AzureApiError on 4xx/5xx" do
@@ -150,7 +150,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
       end
       .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
 
-    body = OpenStruct.new(vm_size: 'Standard_A0')
+    body = { vm_size: 'Standard_A0' }
     @client.put('/test', body, api_version: '2023-01-01')
 
     assert_requested :put, "#{@base_url}/test?api-version=2023-01-01"
@@ -160,18 +160,18 @@ class AzureRestClientTest < ActiveSupport::TestCase
     stub_request(:put, /#{@base_url}/)
       .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
 
-    vm = OpenStruct.new(
+    vm = {
       location: 'eastus',
       tags: { 'env' => 'test' },
-      hardware_profile: OpenStruct.new(vm_size: 'Standard_B2s'),
-      storage_profile: OpenStruct.new(
-        os_disk: OpenStruct.new(disk_size_gb: 30, create_option: 'FromImage')
-      ),
-      os_profile: OpenStruct.new(admin_username: 'azureuser', admin_password: 'secret'),
-      network_profile: OpenStruct.new(
-        network_interfaces: [OpenStruct.new(id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic0', primary: true)]
-      ),
-    )
+      hardware_profile: { vm_size: 'Standard_B2s' },
+      storage_profile: {
+        os_disk: { disk_size_gb: 30, create_option: 'FromImage' }
+      },
+      os_profile: { admin_username: 'azureuser', admin_password: 'secret' },
+      network_profile: {
+        network_interfaces: [{ id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic0', primary: true }]
+      }
+    }
     @client.put('/test', vm, api_version: '2023-01-01')
 
     assert_requested :put, /#{@base_url}/ do |req|
@@ -184,7 +184,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
       assert_equal 'azureuser', body.dig('properties', 'osProfile', 'adminUsername')
       nic_ref = body.dig('properties', 'networkProfile', 'networkInterfaces', 0)
       assert nic_ref['id'].include?('nic0')
-      assert_equal true, nic_ref.dig('properties', 'primary')
+      assert nic_ref.dig('properties', 'primary')
     end
   end
 
@@ -192,18 +192,18 @@ class AzureRestClientTest < ActiveSupport::TestCase
     stub_request(:put, /#{@base_url}/)
       .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
 
-    nic = OpenStruct.new(
+    nic = {
       location: 'eastus',
       ip_configurations: [
-        OpenStruct.new(
+        {
           name: 'ipconfig1',
           private_ipallocation_method: 'Dynamic',
           private_ipaddress: '10.0.0.4',
-          public_ipaddress: OpenStruct.new(id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip0'),
-          subnet: OpenStruct.new(id: '/sub/net'),
-        ),
-      ],
-    )
+          public_ipaddress: { id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip0' },
+          subnet: { id: '/sub/net' }
+        }
+      ]
+    }
     @client.put('/test', nic, api_version: '2023-01-01')
 
     assert_requested :put, /#{@base_url}/ do |req|
@@ -222,7 +222,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
     stub_request(:put, /#{@base_url}/)
       .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
 
-    pip = OpenStruct.new(location: 'eastus', public_ipallocation_method: 'Static')
+    pip = { location: 'eastus', public_ipallocation_method: 'Static' }
     @client.put('/test', pip, api_version: '2023-01-01')
 
     assert_requested :put, /#{@base_url}/ do |req|
@@ -236,14 +236,14 @@ class AzureRestClientTest < ActiveSupport::TestCase
     stub_request(:put, /#{@base_url}/)
       .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
 
-    ext = OpenStruct.new(
+    ext = {
       location: 'eastus',
       publisher: 'Microsoft.Azure.Extensions',
       virtual_machine_extension_type: 'CustomScript',
       type_handler_version: '2.0',
       auto_upgrade_minor_version: true,
-      settings: { 'commandToExecute' => 'echo hello' },
-    )
+      settings: { 'commandToExecute' => 'echo hello' }
+    }
     @client.put('/test', ext, api_version: '2023-01-01')
 
     assert_requested :put, /#{@base_url}/ do |req|
@@ -252,7 +252,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
       assert_equal 'Microsoft.Azure.Extensions', body.dig('properties', 'publisher')
       assert_equal 'CustomScript', body.dig('properties', 'type')
       assert_equal '2.0', body.dig('properties', 'typeHandlerVersion')
-      assert_equal true, body.dig('properties', 'autoUpgradeMinorVersion')
+      assert body.dig('properties', 'autoUpgradeMinorVersion')
       assert_equal 'echo hello', body.dig('properties', 'settings', 'commandToExecute')
     end
   end
@@ -265,8 +265,8 @@ class AzureRestClientTest < ActiveSupport::TestCase
         body: {
           'value' => [
             { 'id' => '/subscriptions/test-sub/resourceGroups/rg-a/providers/Microsoft.Network/virtualNetworks/vnet1', 'name' => 'vnet1', 'location' => 'eastus' },
-            { 'id' => '/subscriptions/test-sub/resourceGroups/rg-b/providers/Microsoft.Network/virtualNetworks/vnet2', 'name' => 'vnet2', 'location' => 'westus' },
-          ],
+            { 'id' => '/subscriptions/test-sub/resourceGroups/rg-b/providers/Microsoft.Network/virtualNetworks/vnet2', 'name' => 'vnet2', 'location' => 'westus' }
+          ]
         }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
@@ -504,6 +504,6 @@ class AzureRestClientTest < ActiveSupport::TestCase
 
     results = @client.get_paged('/items', api_version: '2023-01-01')
 
-    assert_equal [], results
+    assert_empty results
   end
 end

--- a/test/unit/azure_rest_client_test.rb
+++ b/test/unit/azure_rest_client_test.rb
@@ -106,4 +106,103 @@ class AzureRestClientTest < ActiveSupport::TestCase
 
     assert_requested :put, "#{@base_url}/test?api-version=2023-01-01"
   end
+
+  test "polls async operation on 202 Accepted and returns resource" do
+    resource_url = "#{@base_url}/subscriptions/test-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/test-vm?api-version=2024-07-01"
+    poll_url = "#{@base_url}/subscriptions/test-sub/providers/Microsoft.Compute/locations/eastus/operations/op-123?api-version=2024-07-01"
+
+    stub_request(:put, resource_url)
+      .to_return(
+        status: 202,
+        headers: { 'Azure-AsyncOperation' => poll_url, 'Location' => resource_url }
+      )
+
+    stub_request(:get, poll_url)
+      .to_return(
+        { body: { status: 'InProgress' }.to_json, headers: { 'Content-Type' => 'application/json' } },
+        { body: { status: 'Succeeded' }.to_json, headers: { 'Content-Type' => 'application/json' } }
+      )
+
+    stub_request(:get, resource_url)
+      .to_return(body: { name: 'test-vm', location: 'eastus' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    result = @client.put(resource_url, { name: 'test-vm' })
+
+    assert_equal 'test-vm', result.name
+    assert_equal 'eastus', result.location
+    assert_requested :get, poll_url, times: 2
+  end
+
+  test "raises AzureApiError on async poll failure" do
+    resource_url = "#{@base_url}/test?api-version=2023-01-01"
+    poll_url = "#{@base_url}/operations/op-456"
+
+    stub_request(:put, resource_url)
+      .to_return(status: 202, headers: { 'Azure-AsyncOperation' => poll_url })
+
+    stub_request(:get, poll_url)
+      .to_return(body: { status: 'Failed', error: { message: 'Quota exceeded' } }.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+
+    error = assert_raises(ForemanAzureRm::AzureApiError) do
+      @client.put(resource_url, {})
+    end
+    assert_match(/Failed/, error.message)
+    assert_match(/Quota exceeded/, error.message)
+  end
+
+  test "raises AzureApiError on poll HTTP error" do
+    resource_url = "#{@base_url}/test?api-version=2023-01-01"
+    poll_url = "#{@base_url}/operations/op-789"
+
+    stub_request(:put, resource_url)
+      .to_return(status: 202, headers: { 'Azure-AsyncOperation' => poll_url })
+
+    stub_request(:get, poll_url)
+      .to_return(status: 500, body: 'Internal Server Error')
+
+    error = assert_raises(ForemanAzureRm::AzureApiError) do
+      @client.put(resource_url, {})
+    end
+    assert_equal 500, error.status_code
+  end
+
+  test "follows HTTP redirects" do
+    original_url = "#{@base_url}/old-path?api-version=2023-01-01"
+    redirect_url = "#{@base_url}/new-path?api-version=2023-01-01"
+
+    stub_request(:get, original_url)
+      .to_return(status: 301, headers: { 'Location' => redirect_url })
+
+    stub_request(:get, redirect_url)
+      .to_return(body: { name: 'redirected' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    result = @client.get('/old-path', api_version: '2023-01-01')
+
+    assert_equal 'redirected', result.name
+    assert_requested :get, redirect_url
+  end
+
+  test "paginates with get_paged" do
+    page1_url = "#{@base_url}/items?api-version=2023-01-01"
+    page2_url = "#{@base_url}/items?api-version=2023-01-01&skipToken=abc"
+
+    stub_request(:get, page1_url)
+      .to_return(
+        body: { value: [{ name: 'item1' }], nextLink: page2_url }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    stub_request(:get, page2_url)
+      .to_return(
+        body: { value: [{ name: 'item2' }] }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    results = @client.get_paged('/items', api_version: '2023-01-01')
+
+    assert_equal 2, results.length
+    assert_equal 'item1', results[0].name
+    assert_equal 'item2', results[1].name
+  end
 end

--- a/test/unit/azure_rest_client_test.rb
+++ b/test/unit/azure_rest_client_test.rb
@@ -61,13 +61,13 @@ class AzureRestClientTest < ActiveSupport::TestCase
         'hardwareProfile' => { 'vmSize' => 'Standard_B2s' },
         'storageProfile' => {
           'osDisk' => { 'diskSizeGB' => 30, 'osType' => 'Linux', 'caching' => 'ReadWrite' },
-          'imageReference' => { 'publisher' => 'Canonical', 'offer' => 'UbuntuServer', 'sku' => '18.04-LTS', 'version' => 'latest' }
+          'imageReference' => { 'publisher' => 'Canonical', 'offer' => 'UbuntuServer', 'sku' => '18.04-LTS', 'version' => 'latest' },
         },
         'osProfile' => { 'adminUsername' => 'azureuser' },
         'networkProfile' => {
-          'networkInterfaces' => [{ 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic0' }]
-        }
-      }
+          'networkInterfaces' => [{ 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic0' }],
+        },
+      },
     }
 
     stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
@@ -98,10 +98,10 @@ class AzureRestClientTest < ActiveSupport::TestCase
             'privateIPAllocationMethod' => 'Dynamic',
             'publicIPAddress' => { 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip0' },
             'subnet' => { 'id' => '/subscriptions/test-sub/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default' },
-            'primary' => true
-          }
-        }]
-      }
+            'primary' => true,
+          },
+        }],
+      },
     }
 
     stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
@@ -112,9 +112,10 @@ class AzureRestClientTest < ActiveSupport::TestCase
     assert_equal 'nic0', nic.name
     assert_equal 'my-rg', nic.resource_group
     ip_config = nic.ip_configurations.first
+
     assert_equal '10.0.0.4', ip_config.private_ipaddress
     assert_equal 'Dynamic', ip_config.private_ipallocation_method
-    assert ip_config.public_ipaddress.id.include?('pip0')
+    assert_includes ip_config.public_ipaddress.id, 'pip0'
     assert ip_config.primary
   end
 
@@ -165,17 +166,18 @@ class AzureRestClientTest < ActiveSupport::TestCase
       tags: { 'env' => 'test' },
       hardware_profile: { vm_size: 'Standard_B2s' },
       storage_profile: {
-        os_disk: { disk_size_gb: 30, create_option: 'FromImage' }
+        os_disk: { disk_size_gb: 30, create_option: 'FromImage' },
       },
       os_profile: { admin_username: 'azureuser', admin_password: 'secret' },
       network_profile: {
-        network_interfaces: [{ id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic0', primary: true }]
-      }
+        network_interfaces: [{ id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic0', primary: true }],
+      },
     }
     @client.put('/test', vm, api_version: '2023-01-01')
 
     assert_requested :put, /#{@base_url}/ do |req|
       body = JSON.parse(req.body)
+
       assert_equal 'eastus', body['location']
       assert_equal({ 'env' => 'test' }, body['tags'])
       assert_equal 'Standard_B2s', body.dig('properties', 'hardwareProfile', 'vmSize')
@@ -183,7 +185,8 @@ class AzureRestClientTest < ActiveSupport::TestCase
       assert_equal 'FromImage', body.dig('properties', 'storageProfile', 'osDisk', 'createOption')
       assert_equal 'azureuser', body.dig('properties', 'osProfile', 'adminUsername')
       nic_ref = body.dig('properties', 'networkProfile', 'networkInterfaces', 0)
-      assert nic_ref['id'].include?('nic0')
+
+      assert_includes nic_ref['id'], 'nic0'
       assert nic_ref.dig('properties', 'primary')
     end
   end
@@ -200,21 +203,23 @@ class AzureRestClientTest < ActiveSupport::TestCase
           private_ipallocation_method: 'Dynamic',
           private_ipaddress: '10.0.0.4',
           public_ipaddress: { id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip0' },
-          subnet: { id: '/sub/net' }
-        }
-      ]
+          subnet: { id: '/sub/net' },
+        },
+      ],
     }
     @client.put('/test', nic, api_version: '2023-01-01')
 
     assert_requested :put, /#{@base_url}/ do |req|
       body = JSON.parse(req.body)
+
       assert_equal 'eastus', body['location']
       ip_conf = body.dig('properties', 'ipConfigurations', 0)
+
       assert_equal 'ipconfig1', ip_conf['name']
       assert_equal 'Dynamic', ip_conf.dig('properties', 'privateIPAllocationMethod')
       assert_equal '10.0.0.4', ip_conf.dig('properties', 'privateIPAddress')
-      assert ip_conf.dig('properties', 'publicIPAddress', 'id')&.include?('pip0')
-      assert ip_conf.dig('properties', 'subnet', 'id') == '/sub/net'
+      assert_includes ip_conf.dig('properties', 'publicIPAddress', 'id'), 'pip0'
+      assert_equal '/sub/net', ip_conf.dig('properties', 'subnet', 'id')
     end
   end
 
@@ -227,6 +232,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
 
     assert_requested :put, /#{@base_url}/ do |req|
       body = JSON.parse(req.body)
+
       assert_equal 'eastus', body['location']
       assert_equal 'Static', body.dig('properties', 'publicIPAllocationMethod')
     end
@@ -242,12 +248,13 @@ class AzureRestClientTest < ActiveSupport::TestCase
       virtual_machine_extension_type: 'CustomScript',
       type_handler_version: '2.0',
       auto_upgrade_minor_version: true,
-      settings: { 'commandToExecute' => 'echo hello' }
+      settings: { 'commandToExecute' => 'echo hello' },
     }
     @client.put('/test', ext, api_version: '2023-01-01')
 
     assert_requested :put, /#{@base_url}/ do |req|
       body = JSON.parse(req.body)
+
       assert_equal 'eastus', body['location']
       assert_equal 'Microsoft.Azure.Extensions', body.dig('properties', 'publisher')
       assert_equal 'CustomScript', body.dig('properties', 'type')
@@ -265,8 +272,8 @@ class AzureRestClientTest < ActiveSupport::TestCase
         body: {
           'value' => [
             { 'id' => '/subscriptions/test-sub/resourceGroups/rg-a/providers/Microsoft.Network/virtualNetworks/vnet1', 'name' => 'vnet1', 'location' => 'eastus' },
-            { 'id' => '/subscriptions/test-sub/resourceGroups/rg-b/providers/Microsoft.Network/virtualNetworks/vnet2', 'name' => 'vnet2', 'location' => 'westus' }
-          ]
+            { 'id' => '/subscriptions/test-sub/resourceGroups/rg-b/providers/Microsoft.Network/virtualNetworks/vnet2', 'name' => 'vnet2', 'location' => 'westus' },
+          ],
         }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
@@ -315,7 +322,7 @@ class AzureRestClientTest < ActiveSupport::TestCase
 
     stub_request(:get, poll_url)
       .to_return(body: { status: 'Failed', error: { message: 'Quota exceeded' } }.to_json,
-                 headers: { 'Content-Type' => 'application/json' })
+        headers: { 'Content-Type' => 'application/json' })
 
     error = assert_raises(ForemanAzureRm::AzureApiError) do
       @client.put(resource_url, {}, api_version: nil)

--- a/test/unit/azure_rest_client_test.rb
+++ b/test/unit/azure_rest_client_test.rb
@@ -1,0 +1,109 @@
+require_relative '../test_plugin_helper'
+require 'webmock/minitest'
+
+class AzureRestClientTest < ActiveSupport::TestCase
+  setup do
+    @base_url = 'https://management.azure.com'
+    @token_url = 'https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token'
+
+    stub_request(:post, @token_url).to_return(
+      body: { access_token: 'test-token', expires_in: 3600 }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+
+    @client = ForemanAzureRm::AzureRestClient.new(
+      tenant: 'test-tenant',
+      client_id: 'test-client',
+      client_secret: 'test-secret',
+      subscription_id: 'test-sub',
+      azure_environment: 'azure'
+    )
+  end
+
+  test "acquires token on first request" do
+    stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
+      .to_return(body: { value: [] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    @client.get('/test', api_version: '2023-01-01')
+
+    assert_requested :post, @token_url, times: 1
+  end
+
+  test "reuses cached token" do
+    stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
+      .to_return(body: { value: [] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    @client.get('/test', api_version: '2023-01-01')
+    @client.get('/test', api_version: '2023-01-01')
+
+    assert_requested :post, @token_url, times: 1
+  end
+
+  test "wraps JSON response with snake_case OpenStruct" do
+    stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
+      .to_return(
+        body: { 'displayName' => 'East US', 'vmSize' => 'Standard_A0' }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    result = @client.get('/test', api_version: '2023-01-01')
+
+    assert_equal 'East US', result.display_name
+    assert_equal 'Standard_A0', result.vm_size
+  end
+
+  test "wraps nested JSON with recursive OpenStruct" do
+    stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
+      .to_return(
+        body: {
+          'properties' => {
+            'hardwareProfile' => { 'vmSize' => 'Standard_B2s' },
+            'storageProfile' => {
+              'osDisk' => { 'diskSizeGb' => 30 },
+            },
+          },
+        }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    result = @client.get('/test', api_version: '2023-01-01')
+
+    assert_equal 'Standard_B2s', result.properties.hardware_profile.vm_size
+    assert_equal 30, result.properties.storage_profile.os_disk.disk_size_gb
+  end
+
+  test "raises AzureApiError on 4xx/5xx" do
+    stub_request(:get, "#{@base_url}/test?api-version=2023-01-01")
+      .to_return(
+        status: 404,
+        body: { error: { code: 'ResourceNotFound', message: 'Not found' } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    error = assert_raises(ForemanAzureRm::AzureApiError) do
+      @client.get('/test', api_version: '2023-01-01')
+    end
+    assert_equal 404, error.status_code
+    assert_match(/Not found/, error.message)
+  end
+
+  test "raises on invalid azure environment" do
+    assert_raises(ArgumentError) do
+      ForemanAzureRm::AzureRestClient.new(
+        tenant: 't', client_id: 'c', client_secret: 's',
+        subscription_id: 'sub', azure_environment: 'invalid'
+      )
+    end
+  end
+
+  test "serializes OpenStruct body with camelCase keys" do
+    stub_request(:put, "#{@base_url}/test?api-version=2023-01-01")
+      .with { |req| JSON.parse(req.body)['vmSize'] == 'Standard_A0' }
+      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+    body = OpenStruct.new(vm_size: 'Standard_A0')
+    @client.put('/test', body, api_version: '2023-01-01')
+
+    assert_requested :put, "#{@base_url}/test?api-version=2023-01-01"
+  end
+end

--- a/test/unit/azure_rm_test.rb
+++ b/test/unit/azure_rm_test.rb
@@ -53,8 +53,8 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
       assert_equal "rg1", actual_server.resource_group
       assert actual_server.password.present?
       assert_equal 1, actual_server.interfaces.count
-      refute actual_server.azure_vm.disable_password_authentication
-      refute actual_server.azure_vm.os_profile.custom_data.present?
+      assert_not actual_server.azure_vm.disable_password_authentication
+      assert_not actual_server.azure_vm.os_profile.custom_data.present?
     end
 
     test "create vm with password, custom data and vm extension" do
@@ -72,7 +72,7 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
 
       assert_equal "testpswd123", actual_server.password
       assert actual_server.azure_vm.os_profile.custom_data.present?
-      refute actual_server.azure_vm.disable_password_authentication
+      assert_not actual_server.azure_vm.disable_password_authentication
     end
 
     test "create vm with sshkey and without custom data" do
@@ -84,7 +84,7 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
       actual_server = @azure_cr.create_vm(vm_args)
 
       assert actual_server.azure_vm.disable_password_authentication
-      refute actual_server.azure_vm.os_profile.custom_data.present?
+      assert_not actual_server.azure_vm.os_profile.custom_data.present?
     end
 
     test "create vm with sshkey, custom data and vm extension" do
@@ -132,7 +132,7 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
       vm_args = base_vm_args.merge(with_password_auth).merge(with_gallery_image)
       actual_server = @azure_cr.create_vm(vm_args)
 
-      refute actual_server.azure_vm.disable_password_authentication
+      assert_not actual_server.azure_vm.disable_password_authentication
       assert_equal "testpswd123", actual_server.password
       assert_equal "gallery://rg1/first_gallery/first_gallery_img", actual_server.image_id
     end

--- a/test/unit/azure_rm_test.rb
+++ b/test/unit/azure_rm_test.rb
@@ -3,6 +3,7 @@ require_relative '../azure_rm_test_helper'
 
 class ForemanAzureRmTest < ActiveSupport::TestCase
   include AzureRmTestHelper
+
   setup do
     @mock_sdk = mock('mock_sdk')
     ForemanAzureRm::AzureRm.any_instance.stubs(:sdk).returns(@mock_sdk)
@@ -26,13 +27,15 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
     cloud = %w[azure azureusgovernment azurechina azuregermancloud].sample
     ForemanAzureRm::AzureRm.any_instance.stubs(:validate_cloud?).returns(true)
     @azure_cr.cloud=(cloud)
-    assert @azure_cr.validate_cloud?
+
+    assert_predicate @azure_cr, :validate_cloud?
   end
 
   test "list all resource groups" do
     mock_resource_client = mock('mock_resource_client')
     @mock_sdk.stubs(:resource_client).returns(mock_resource_client)
     @mock_sdk.stubs(:rgs).returns(['rg1', 'rg2', 'rg3'])
+
     assert ['rg1', 'rg2', 'rg3'], @azure_cr.resource_groups
   end
 
@@ -51,7 +54,7 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
 
       assert_equal "ervin-golomb", actual_server.name
       assert_equal "rg1", actual_server.resource_group
-      assert actual_server.password.present?
+      assert_predicate actual_server.password, :present?
       assert_equal 1, actual_server.interfaces.count
       assert_not actual_server.azure_vm.disable_password_authentication
       assert_not actual_server.azure_vm.os_profile.custom_data.present?
@@ -71,7 +74,7 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
       actual_server = @azure_cr.create_vm(vm_args)
 
       assert_equal "testpswd123", actual_server.password
-      assert actual_server.azure_vm.os_profile.custom_data.present?
+      assert_predicate actual_server.azure_vm.os_profile.custom_data, :present?
       assert_not actual_server.azure_vm.disable_password_authentication
     end
 
@@ -101,7 +104,7 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
       actual_server = @azure_cr.create_vm(vm_args)
 
       assert actual_server.azure_vm.disable_password_authentication
-      assert actual_server.azure_vm.os_profile.custom_data.present?
+      assert_predicate actual_server.azure_vm.os_profile.custom_data, :present?
     end
 
     test "create vm with custom image and sshkey" do

--- a/test/unit/azure_rm_test.rb
+++ b/test/unit/azure_rm_test.rb
@@ -123,11 +123,10 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
 
 
     test "create vm with shared image gallery and password" do
+      gallery_arm_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/galleries/first_gallery/images/first_gallery_img"
       @mock_vm.stubs(:disable_password_authentication).returns(false)
-      @mock_sdk.expects(:fetch_gallery_image_id).with("rg1", "first_gallery_img").returns("/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/galleries/first_gallery/images/first_gallery_img").times(2)
-      mock_gallery_image = mock('mock_gallery_image')
-      mock_gallery_image.stubs(:id).returns('/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/galleries/first_gallery/images/first_gallery_img')
-      @mock_vm.storage_profile.image_reference.stubs(:id).returns('/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/galleries/first_gallery/images/first_gallery_img')
+      @mock_sdk.expects(:fetch_gallery_image_id).with("rg1", "first_gallery_img").returns(gallery_arm_id)
+      @mock_vm.storage_profile.image_reference.stubs(:id).returns(gallery_arm_id)
       @mock_sdk.stubs(:list_custom_images).returns([])
       mock_create_or_update_vm_with_password
       vm_args = base_vm_args.merge(with_password_auth).merge(with_gallery_image)
@@ -135,7 +134,7 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
 
       refute actual_server.azure_vm.disable_password_authentication
       assert_equal "testpswd123", actual_server.password
-      assert_equal "gallery://first_gallery_img", actual_server.image_id
+      assert_equal "gallery://rg1/first_gallery/first_gallery_img", actual_server.image_id
     end
   end
 end

--- a/test/unit/azure_sdk_adapter_test.rb
+++ b/test/unit/azure_sdk_adapter_test.rb
@@ -23,7 +23,7 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
 
   test "resolves canonical 3-part gallery image ID directly" do
     gallery_arm_id = '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery/images/myimage'
-    mock_image = OpenStruct.new(name: 'myimage', id: gallery_arm_id)
+    mock_image = stub(name: 'myimage', id: gallery_arm_id)
     @test_adapter.expects(:list_gallery_images).with('rg1', 'mygallery').returns([mock_image])
 
     result = @test_adapter.send(:actual_gallery_image_id, nil, 'rg1/mygallery/myimage')
@@ -31,8 +31,8 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
   end
 
   test "resolves 2-part gallery image ID when unique" do
-    gallery = OpenStruct.new(name: 'mygallery', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery')
-    mock_image = OpenStruct.new(name: 'myimage', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery/images/myimage')
+    gallery = stub(name: 'mygallery', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery')
+    mock_image = stub(name: 'myimage', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery/images/myimage')
     @test_adapter.expects(:list_galleries).returns([gallery])
     @test_adapter.expects(:list_gallery_images).with('rg1', 'mygallery').returns([mock_image])
 
@@ -41,10 +41,10 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
   end
 
   test "raises on ambiguous 1-part gallery image ID" do
-    gallery1 = OpenStruct.new(name: 'gallery1', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/gallery1')
-    gallery2 = OpenStruct.new(name: 'gallery2', resource_group: 'rg2', id: '/subscriptions/sub/resourceGroups/rg2/providers/Microsoft.Compute/galleries/gallery2')
-    img1 = OpenStruct.new(name: 'shared-img', id: 'id1')
-    img2 = OpenStruct.new(name: 'shared-img', id: 'id2')
+    gallery1 = stub(name: 'gallery1', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/gallery1')
+    gallery2 = stub(name: 'gallery2', resource_group: 'rg2', id: '/subscriptions/sub/resourceGroups/rg2/providers/Microsoft.Compute/galleries/gallery2')
+    img1 = stub(name: 'shared-img', id: 'id1')
+    img2 = stub(name: 'shared-img', id: 'id2')
     @test_adapter.expects(:list_galleries).returns([gallery1, gallery2])
     @test_adapter.expects(:list_gallery_images).with('rg1', 'gallery1').returns([img1])
     @test_adapter.expects(:list_gallery_images).with('rg2', 'gallery2').returns([img2])
@@ -63,15 +63,15 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
 
     assert_equal 'arm-id-a', ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage']
     assert_equal 'arm-id-b', ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
-    refute_equal ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage'],
-                 ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
+    assert_not_equal ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage'],
+                     ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
   end
 
   test "raises on ambiguous 2-part gallery image ID across resource groups" do
-    gallery_rg1 = OpenStruct.new(name: 'shared-gallery', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/shared-gallery')
-    gallery_rg2 = OpenStruct.new(name: 'shared-gallery', resource_group: 'rg2', id: '/subscriptions/sub/resourceGroups/rg2/providers/Microsoft.Compute/galleries/shared-gallery')
-    img1 = OpenStruct.new(name: 'myimage', id: 'id1')
-    img2 = OpenStruct.new(name: 'myimage', id: 'id2')
+    gallery_rg1 = stub(name: 'shared-gallery', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/shared-gallery')
+    gallery_rg2 = stub(name: 'shared-gallery', resource_group: 'rg2', id: '/subscriptions/sub/resourceGroups/rg2/providers/Microsoft.Compute/galleries/shared-gallery')
+    img1 = stub(name: 'myimage', id: 'id1')
+    img2 = stub(name: 'myimage', id: 'id2')
     @test_adapter.expects(:list_galleries).returns([gallery_rg1, gallery_rg2])
     @test_adapter.expects(:list_gallery_images).with('rg1', 'shared-gallery').returns([img1])
     @test_adapter.expects(:list_gallery_images).with('rg2', 'shared-gallery').returns([img2])

--- a/test/unit/azure_sdk_adapter_test.rb
+++ b/test/unit/azure_sdk_adapter_test.rb
@@ -9,15 +9,76 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
     sub_id           = compute_resource.user
     cloud            = compute_resource.cloud
     @test_adapter    = ForemanAzureRm::AzureSdkAdapter.new(tenant, app_ident, secret_key, sub_id, cloud)
-    ForemanAzureRm::AzureSdkAdapter.stubs(:gallery_caching).with('test_rg').returns({})
+    ForemanAzureRm::AzureSdkAdapter.instance_variable_set(:@gallery_cache, {})
   end
 
-  test "should call #actual_gallery_image_id when #gallery_caching is {} otherwise return #gallery_caching" do
-    @test_adapter.expects(:actual_gallery_image_id).with('test_rg', 'test_gallery_image_name').once.returns('test_gallery_img_id')
-    actual1 = @test_adapter.fetch_gallery_image_id('test_rg', 'test_gallery_image_name')
-    actual2 = @test_adapter.fetch_gallery_image_id('test_rg', 'test_gallery_image_name')
+  test "caches gallery image ID lookups" do
+    @test_adapter.expects(:actual_gallery_image_id).with(nil, 'test_gallery_image_name').once.returns('test_gallery_img_id')
+    actual1 = @test_adapter.fetch_gallery_image_id(nil, 'test_gallery_image_name')
+    actual2 = @test_adapter.fetch_gallery_image_id(nil, 'test_gallery_image_name')
 
     assert_equal actual1, actual2
     assert_equal 'test_gallery_img_id', actual1
+  end
+
+  test "resolves canonical 3-part gallery image ID directly" do
+    gallery_arm_id = '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery/images/myimage'
+    mock_image = OpenStruct.new(name: 'myimage', id: gallery_arm_id)
+    @test_adapter.expects(:list_gallery_images).with('rg1', 'mygallery').returns([mock_image])
+
+    result = @test_adapter.send(:actual_gallery_image_id, nil, 'rg1/mygallery/myimage')
+    assert_equal gallery_arm_id, result
+  end
+
+  test "resolves 2-part gallery image ID when unique" do
+    gallery = OpenStruct.new(name: 'mygallery', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery')
+    mock_image = OpenStruct.new(name: 'myimage', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/mygallery/images/myimage')
+    @test_adapter.expects(:list_galleries).returns([gallery])
+    @test_adapter.expects(:list_gallery_images).with('rg1', 'mygallery').returns([mock_image])
+
+    result = @test_adapter.send(:actual_gallery_image_id, nil, 'mygallery/myimage')
+    assert_match(/myimage$/, result)
+  end
+
+  test "raises on ambiguous 1-part gallery image ID" do
+    gallery1 = OpenStruct.new(name: 'gallery1', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/gallery1')
+    gallery2 = OpenStruct.new(name: 'gallery2', resource_group: 'rg2', id: '/subscriptions/sub/resourceGroups/rg2/providers/Microsoft.Compute/galleries/gallery2')
+    img1 = OpenStruct.new(name: 'shared-img', id: 'id1')
+    img2 = OpenStruct.new(name: 'shared-img', id: 'id2')
+    @test_adapter.expects(:list_galleries).returns([gallery1, gallery2])
+    @test_adapter.expects(:list_gallery_images).with('rg1', 'gallery1').returns([img1])
+    @test_adapter.expects(:list_gallery_images).with('rg2', 'gallery2').returns([img2])
+
+    assert_raises(ArgumentError) do
+      @test_adapter.send(:actual_gallery_image_id, nil, 'shared-img')
+    end
+  end
+
+  test "gallery cache is scoped per subscription" do
+    sub_a = 'subscription-a'
+    sub_b = 'subscription-b'
+
+    ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage'] = 'arm-id-a'
+    ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage'] = 'arm-id-b'
+
+    assert_equal 'arm-id-a', ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage']
+    assert_equal 'arm-id-b', ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
+    refute_equal ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage'],
+                 ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
+  end
+
+  test "raises on ambiguous 2-part gallery image ID across resource groups" do
+    gallery_rg1 = OpenStruct.new(name: 'shared-gallery', resource_group: 'rg1', id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/galleries/shared-gallery')
+    gallery_rg2 = OpenStruct.new(name: 'shared-gallery', resource_group: 'rg2', id: '/subscriptions/sub/resourceGroups/rg2/providers/Microsoft.Compute/galleries/shared-gallery')
+    img1 = OpenStruct.new(name: 'myimage', id: 'id1')
+    img2 = OpenStruct.new(name: 'myimage', id: 'id2')
+    @test_adapter.expects(:list_galleries).returns([gallery_rg1, gallery_rg2])
+    @test_adapter.expects(:list_gallery_images).with('rg1', 'shared-gallery').returns([img1])
+    @test_adapter.expects(:list_gallery_images).with('rg2', 'shared-gallery').returns([img2])
+
+    error = assert_raises(ArgumentError) do
+      @test_adapter.send(:actual_gallery_image_id, nil, 'shared-gallery/myimage')
+    end
+    assert_match(/ambiguous/, error.message)
   end
 end

--- a/test/unit/azure_sdk_adapter_test.rb
+++ b/test/unit/azure_sdk_adapter_test.rb
@@ -27,6 +27,7 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
     @test_adapter.expects(:list_gallery_images).with('rg1', 'mygallery').returns([mock_image])
 
     result = @test_adapter.send(:actual_gallery_image_id, nil, 'rg1/mygallery/myimage')
+
     assert_equal gallery_arm_id, result
   end
 
@@ -37,6 +38,7 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
     @test_adapter.expects(:list_gallery_images).with('rg1', 'mygallery').returns([mock_image])
 
     result = @test_adapter.send(:actual_gallery_image_id, nil, 'mygallery/myimage')
+
     assert_match(/myimage$/, result)
   end
 
@@ -64,7 +66,7 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
     assert_equal 'arm-id-a', ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage']
     assert_equal 'arm-id-b', ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
     assert_not_equal ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_a)['myimage'],
-                     ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
+      ForemanAzureRm::AzureSdkAdapter.gallery_cache(sub_b)['myimage']
   end
 
   test "raises on ambiguous 2-part gallery image ID across resource groups" do


### PR DESCRIPTION
## Summary

The Azure SDK for Ruby was retired in December 2021 and archived in January 2023. Its transitive dependency on `ms_rest` pins `faraday < 2`, blocking the entire Foreman/Katello ecosystem from upgrading to Faraday 2.x — which is needed for persistent TCP+TLS connection reuse between Puma and Candlepin (see Katello PR linked below).

This PR replaces all 5 `azure_mgmt_*` gems with a lightweight `AzureRestClient` that uses `Net::HTTP` directly for Azure REST API calls with OAuth2 `client_credentials` authentication.

- **AzureRestClient**: Net::HTTP transport, OAuth2 token management with caching and auto-refresh, recursive OpenStruct response wrapping with camelCase-to-snake_case conversion, async operation polling with bounded timeout
- **AzureSdkAdapter**: all 32 API methods rewritten using REST path helpers
- **Rollback safety**: `create_vm` properly cleans up NICs and PIPs on failure, even when the VM was never created
- **`build_http` / `best_effort` helpers**: centralized Net::HTTP setup and block-based cleanup that logs failures without masking the original exception
- Removes 15 pseudo-SDK OpenStruct aliases that added no type safety
- Keeps enum constants (CachingTypes, StorageAccountTypes, etc.)

### Bugs fixed
- `AzureApiError` namespace mismatch — rescue referenced non-existent `AzureRestClient::AzureApiError` instead of `ForemanAzureRm::AzureApiError`, causing Azure API failures to skip rollback
- NIC/PIP leak on failed VM creation — `destroy_vm` cannot find a VM that was never created, leaving orphaned network resources
- Gallery image format inconsistency — `image_exists?` now handles both `gallery://image_name` and `gallery://gallery_name/image_name`
- Async polling checked `HTTPSuccess` before `HTTPAccepted` (202 inherits from HTTPSuccess), causing async operations to return immediately instead of polling
- VM extension settings used camelCase accessors instead of snake_case (post deep_underscore_keys transform)

### Gemspec changes

Removed:
- azure_mgmt_compute (~> 0.22.0)
- azure_mgmt_network (~> 0.26.1)
- azure_mgmt_resources (~> 0.18.2)
- azure_mgmt_storage (~> 0.23.0)
- azure_mgmt_subscriptions (~> 0.18.5)

Added:
- oauth2 (~> 2.0)

### Packaging note
RPM packages that currently depend on `rubygem-azure_mgmt_*` and `rubygem-ms_rest*` will need to drop those dependencies and add `rubygem-oauth2` instead.

## Test plan
- [x] Unit tests for async polling (success, failure, HTTP error)
- [x] Unit tests for HTTP redirect following
- [x] Unit tests for paginated responses
- [ ] Integration test: VM create/destroy lifecycle
- [ ] Integration test: VM create failure — verify NIC/PIP cleanup
- [ ] Integration test: gallery image lookup with short format
- [ ] Verify existing Foreman Azure RM test suite passes

Generated with [Claude Code](https://claude.com/claude-code)
