### PR TITLE
Fixes SAT-48157 - Fix Azure Gallery image parsing and Marketplace pla…

### DIFF
--- a/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -237,11 +237,17 @@ module ForemanAzureRm
     end
 
     def actual_gallery_image_id(rg_name, image_id)
-      gallery_names = list_galleries.map(&:name)
-      return unless (gallery = gallery_names.first)
+      # Parse gallery name and image name from image_id
+      # Format: gallery_name/image_name (e.g., RHSG_1/RHEL77img)
+      gallery_name, image_name = image_id.split("/", 2)
+      return unless gallery_name && image_name
 
-      gallery_image = list_gallery_images(rg_name, gallery).detect { |image| image.name == image_id }
+      # Search for the image in the specified gallery
+      gallery_image = list_gallery_images(rg_name, gallery_name).detect { |image| image.name == image_name }
       gallery_image&.id
+    rescue StandardError => e
+      Foreman::Logging.exception("Failed to fetch gallery image", e)
+      nil
     end
 
     def fetch_gallery_image_id(rg_name, image_id)

--- a/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
+++ b/app/models/concerns/foreman_azure_rm/vm_extensions/managed_vm.rb
@@ -62,7 +62,7 @@ module ForemanAzureRm
 
       def marketplace_image_plan(image)
         image_type, image_id = image.split('://')
-        return nil unless image_type == 'marketplace' && image_id.include?('byos')
+        return nil unless image_type == 'marketplace'
         urn = image_id.split(':')
         publisher = urn[0]
         offer     = urn[1]

--- a/test/azure_rm_test_helper.rb
+++ b/test/azure_rm_test_helper.rb
@@ -133,3 +133,12 @@ module AzureRmTestHelper
     }
   end
 end
+
+# Test helper for SAT-48157 - Marketplace image without BYOS
+def with_cis_marketplace_image
+  { "image_id" => "marketplace://center-for-internet-security-inc:cis-rhel:cis-redhat9-l1-gen2:latest" }
+end
+
+def with_marketplace_byos_image
+  { "image_id" => "marketplace://publisher:offer-byos:sku:latest" }
+end

--- a/test/unit/azure_rm_test.rb
+++ b/test/unit/azure_rm_test.rb
@@ -138,4 +138,48 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
       assert_equal "gallery://first_gallery_img", actual_server.image_id
     end
   end
+
+  test "create vm with gallery image using gallery_name/image_name format" do
+    # Mock the SDK to return gallery image ID with proper parsing
+    gallery_image_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/galleries/RHSG_1/images/RHEL77img"
+    @mock_sdk.expects(:fetch_gallery_image_id).with("rg1", "RHSG_1/RHEL77img").returns(gallery_image_id).times(2)
+
+    mock_gallery_image = mock('mock_gallery_image')
+    mock_gallery_image.stubs(:id).returns(gallery_image_id)
+    @mock_vm.storage_profile.image_reference.stubs(:id).returns(gallery_image_id)
+    @mock_sdk.stubs(:list_custom_images).returns([])
+
+    mock_create_or_update_vm_with_password
+
+    vm_args = base_vm_args.merge(with_password_auth).merge({ "image_id" => "gallery://RHSG_1/RHEL77img" })
+    actual_server = @azure_cr.create_vm(vm_args)
+
+    refute actual_server.azure_vm.disable_password_authentication
+    assert_equal "testpswd123", actual_server.password
+    assert_equal "gallery://RHSG_1/RHEL77img", actual_server.image_id
+  end
+
+  test "create vm with CIS marketplace image should include plan" do
+    @mock_vm.stubs(:disable_password_authentication).returns(false)
+    @mock_vm.os_profile.stubs(:custom_data)
+
+    # The plan should be created for non-BYOS marketplace images
+    @mock_sdk.expects(:create_or_update_vm).with do |rg, name, params|
+      # Verify plan is present
+      params.plan.present? &&
+      params.plan.publisher == "center-for-internet-security-inc" &&
+      params.plan.product == "cis-rhel" &&
+      params.plan.name == "cis-redhat9-l1-gen2"
+    end.returns(@mock_vm)
+
+    @mock_sdk.stubs(:list_custom_images).returns([])
+    @mock_vm.stubs(:vm_id).returns('12345')
+    @mock_vm.stubs(:properties).returns(mock())
+    @mock_vm.properties.stubs(:provisioning_state).returns('Succeeded')
+
+    vm_args = base_vm_args.merge(with_password_auth).merge(with_cis_marketplace_image)
+    actual_server = @azure_cr.create_vm(vm_args)
+
+    assert_equal "marketplace://center-for-internet-security-inc:cis-rhel:cis-redhat9-l1-gen2:latest", actual_server.image_id
+  end
 end

--- a/test/unit/azure_sdk_adapter_test.rb
+++ b/test/unit/azure_sdk_adapter_test.rb
@@ -21,3 +21,42 @@ class AzureSdkAdapterTest < ActiveSupport::TestCase
     assert_equal 'test_gallery_img_id', actual1
   end
 end
+
+# Test for SAT-48157 - Gallery image bug fix
+test "should correctly parse gallery name and image name from image_id" do
+  # Mock the list_gallery_images to return a test gallery image
+  mock_gallery_image = mock('mock_gallery_image')
+  mock_gallery_image.stubs(:name).returns('RHEL77img')
+  mock_gallery_image.stubs(:id).returns('/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Compute/galleries/RHSG_1/images/RHEL77img')
+
+  @test_adapter.expects(:list_gallery_images).with('test_rg', 'RHSG_1').returns([mock_gallery_image])
+
+  # Test with format: gallery_name/image_name
+  result = @test_adapter.actual_gallery_image_id('test_rg', 'RHSG_1/RHEL77img')
+
+  assert_equal '/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Compute/galleries/RHSG_1/images/RHEL77img', result
+end
+
+test "should return nil when gallery image is not found" do
+  # Mock list_gallery_images to return empty array
+  @test_adapter.expects(:list_gallery_images).with('test_rg', 'NonExistentGallery').returns([])
+
+  result = @test_adapter.actual_gallery_image_id('test_rg', 'NonExistentGallery/NonExistentImage')
+
+  assert_nil result
+end
+
+test "should return nil when image_id format is invalid" do
+  # No gallery name separator
+  result = @test_adapter.actual_gallery_image_id('test_rg', 'invalid_format')
+
+  assert_nil result
+end
+
+test "should handle exceptions gracefully in actual_gallery_image_id" do
+  @test_adapter.expects(:list_gallery_images).raises(StandardError, 'Azure API error')
+
+  result = @test_adapter.actual_gallery_image_id('test_rg', 'RHSG_1/RHEL77img')
+
+  assert_nil result
+end

--- a/test/unit/managed_vm_test.rb
+++ b/test/unit/managed_vm_test.rb
@@ -1,0 +1,71 @@
+require_relative '../test_plugin_helper'
+
+class ManagedVMTest < ActiveSupport::TestCase
+  # Create a test class that includes the ManagedVM concern
+  class TestVMExtensions
+    include ForemanAzureRm::VMExtensions::ManagedVM
+  end
+
+  setup do
+    @vm_extensions = TestVMExtensions.new
+  end
+
+  # Tests for SAT-48157 - Marketplace Plan Bug Fix
+
+  test "should create plan for marketplace image without byos" do
+    # Test with CIS marketplace image from SAT-48157
+    image = "marketplace://center-for-internet-security-inc:cis-rhel:cis-redhat9-l1-gen2:latest"
+
+    plan = @vm_extensions.marketplace_image_plan(image)
+
+    assert_not_nil plan, "Plan should be created for non-BYOS marketplace images"
+    assert_equal "center-for-internet-security-inc", plan.publisher
+    assert_equal "cis-rhel", plan.product
+    assert_equal "cis-redhat9-l1-gen2", plan.name
+  end
+
+  test "should create plan for marketplace image with byos" do
+    image = "marketplace://publisher:offer-byos:sku:latest"
+
+    plan = @vm_extensions.marketplace_image_plan(image)
+
+    assert_not_nil plan, "Plan should be created for BYOS marketplace images"
+    assert_equal "publisher", plan.publisher
+    assert_equal "offer-byos", plan.product
+    assert_equal "sku", plan.name
+  end
+
+  test "should create plan for standard marketplace image" do
+    # Standard OpenLogic CentOS image
+    image = "marketplace://OpenLogic:CentOS:7.5:latest"
+
+    plan = @vm_extensions.marketplace_image_plan(image)
+
+    assert_not_nil plan, "Plan should be created for all marketplace images"
+    assert_equal "openlogic", plan.publisher
+    assert_equal "centos", plan.product
+    assert_equal "7.5", plan.name
+  end
+
+  test "should return nil for non-marketplace images" do
+    # Custom image
+    custom_image = "custom://my-custom-image"
+    plan = @vm_extensions.marketplace_image_plan(custom_image)
+    assert_nil plan, "Plan should not be created for custom images"
+
+    # Gallery image
+    gallery_image = "gallery://RHSG_1/RHEL77img"
+    plan = @vm_extensions.marketplace_image_plan(gallery_image)
+    assert_nil plan, "Plan should not be created for gallery images"
+  end
+
+  test "should handle plan values as lowercase" do
+    image = "marketplace://PUBLISHER:OFFER:SKU:latest"
+
+    plan = @vm_extensions.marketplace_image_plan(image)
+
+    assert_equal "publisher", plan.publisher, "Publisher should be lowercase"
+    assert_equal "offer", plan.product, "Product should be lowercase"
+    assert_equal "sku", plan.name, "Name should be lowercase"
+  end
+end


### PR DESCRIPTION
**Bug #1: Gallery images send empty imageReference to Azure API**
---------------------------------------------------------------
Problem: When provisioning with gallery images (format: gallery://RHSG_1/RHEL77img),
the code only checked the first gallery in the list instead of parsing the
gallery_name from the image_id. This resulted in sending empty imageReference: {}
to Azure, causing InvalidParameter errors.

Fix: Modified actual_gallery_image_id to parse gallery_name/image_name from the
image_id format and look up the image in the specified gallery.

**Bug #2: Marketplace images missing required plan block**
-------------------------------------------------------
Problem: The marketplace_image_plan method only created purchase plan metadata
for images containing 'byos' in the name. Many marketplace images (e.g., CIS RHEL)
require plan information but don't have 'byos' in the name, causing
VMMarketplaceInvalidInput errors.

**Fix:** 
Removed the BYOS name restriction. Now creates plan for ALL marketplace
images. Azure will ignore the plan if not required, but will fail if the plan
is missing when required.

_Assisted by Claude_ 